### PR TITLE
Correspond to "zh" locale access

### DIFF
--- a/lib/lokka/before.rb
+++ b/lib/lokka/before.rb
@@ -18,7 +18,7 @@ module Lokka
         elsif session[:locale]
           I18n.locale = session[:locale]
         elsif locales.present?
-          I18n.locale = locales.first
+          I18n.locale = (I18n.available_locales & locales).first
         end
 
         theme = request.cookies['theme']


### PR DESCRIPTION
As i18n.gem doesn't support local "zh" check if user's request locale
is included in `I18n.available_locales` before set it as locale.
If fail, it falls back to `I18n.default_locale` (i18n.gem's behavior)