### PR TITLE
Update CircleCI pipeline to Ruby 3.0 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,13 @@ jobs:
   build:
     working_directory: ~/app
     docker:
-      - image: circleci/ruby:2.7-node
+      - image: cimg/ruby:3.0-node
         environment:
           RAILS_ENV: test
     steps:
-      # - run:
-      #     name: Install Dependencies
-      #     command: |
-      #       apt-get install -y sqlite3
-      - run: gem i bundler:2.1.2
+      - run:
+          name: Update bundler
+          command: gem install bundler:2.4.22
       - checkout
       - restore_cache:
           key: portalshit-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
## Summary
- switch the CircleCI build job to the cimg Ruby 3.0 image so it matches the Gemfile requirement
- install Bundler 2.4.22 before running `bundle install`

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_b_690be73c5efc8321bcc5b79419cb4d2f