### PR TITLE
Upgrade RSpec to 3.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,8 @@ group :development, :test do
   gem 'database_cleaner-active_record'
   gem 'factory_girl', '~> 4.0'
   gem 'rack-test', require: 'rack/test'
-  gem 'rspec', '~> 2.99'
+  gem 'rspec', '~> 3.12'
+  gem 'rspec-its'
   gem 'simplecov', require: false
   gem 'sqlite3', group: :batch
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,14 +309,22 @@ GEM
       rack-test (>= 0.5)
       ripl (>= 0.3.5)
     rouge (4.5.1)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.5.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     rubocop (1.71.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -469,7 +477,8 @@ DEPENDENCIES
   redcarpet
   request_store
   rouge
-  rspec (~> 2.99)
+  rspec (~> 3.12)
+  rspec-its
   rubocop
   ruby-openai
   sass (< 3.7.4)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'rubygems'
 require 'sinatra'
 require 'rack/test'
 require 'rspec'
+require 'rspec/its'
 require 'factory_girl'
 require 'database_cleaner/active_record'
 require 'pry'
@@ -36,6 +37,9 @@ end
 
 RSpec.configure do |config|
   config.mock_with :rspec
+  config.expect_with(:rspec) do |expectations|
+    expectations.syntax = %i[expect should]
+  end
   config.include Rack::Test::Methods
   config.include LokkaTestMethods
   config.include Lokka::Helpers

--- a/spec/unit/post_spec.rb
+++ b/spec/unit/post_spec.rb
@@ -34,7 +34,7 @@ describe Post do
     context 'when an invalid slug is specified' do
       subject { build :post, slug: 'invalid string' }
       it 'should be invalid or created with a different name' do
-        (!subject.valid? || subject.slug != 'invalid string').should be_true
+        (!subject.valid? || subject.slug != 'invalid string').should be true
       end
     end
   end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -7,14 +7,14 @@ describe User do
 
   shared_examples 'user with validation' do
     it 'saves successfully' do
-      subject.save.should be_true
+      subject.save.should be true
     end
 
     context 'with blank name' do
       before { user.name = '' }
 
       it 'fails to save' do
-        subject.save.should_not be_true
+        subject.save.should_not be true
       end
     end
 
@@ -22,7 +22,7 @@ describe User do
       before { user.email = '' }
 
       it 'fails to save' do
-        subject.save.should_not be_true
+        subject.save.should_not be true
       end
     end
 


### PR DESCRIPTION
## Summary
- bump the RSpec dependency to the 3.12 series and add rspec-its support
- configure the test suite to keep :should syntax compatibility
- update legacy specs to satisfy RSpec 3 matcher expectations

## Testing
- bundle exec rspec *(fails: bundler: command not found: rspec; bundle install was blocked by network restrictions when fetching git-based dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_690ad116d0e48321a37e13060576b7c7