### PR TITLE
Refactor knowledge exporter into focused collaborators

### DIFF
--- a/lib/dify/article_collector.rb
+++ b/lib/dify/article_collector.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'dify/article_formatter'
+
+module Dify
+  class ArticleCollector
+    attr_reader :formatter, :scope
+
+    def initialize(base_url:, scope: default_scope)
+      @formatter = ArticleFormatter.new(base_url: base_url)
+      @scope = scope
+    end
+
+    def collect(label:)
+      rows = []
+
+      scope.find_each do |post|
+        next if block_given? && !yield(post)
+
+        rows << formatter.article_hash(post)
+      rescue => e
+        warn "[#{label}] skip id=#{post.respond_to?(:id) ? post.id : 'n/a'}: #{e.class} #{e.message}"
+      end
+
+      rows
+    end
+
+    def compose_year_text(posts, delimiter: nil)
+      if delimiter.nil?
+        formatter.compose_year_text(posts)
+      else
+        formatter.compose_year_text(posts, delimiter: delimiter)
+      end
+    end
+
+    def build_url_for(post)
+      formatter.build_url_for(post)
+    end
+
+    private
+
+    def default_scope
+      Entry.published.includes(:tags, :category)
+    end
+  end
+end

--- a/lib/dify/article_formatter.rb
+++ b/lib/dify/article_formatter.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'cgi'
+require 'nokogiri'
+
+module Dify
+  class ArticleFormatter
+    attr_reader :base_url
+
+    def initialize(base_url: '')
+      @base_url = (base_url || '').to_s
+    end
+
+    def article_hash(post)
+      {
+        id:      safe_send(post, :id),
+        title:   safe_send(post, :title).to_s,
+        date:    safe_send(post, :created_at)&.to_date&.to_s,
+        tags:    extract_tags(post),
+        slug:    safe_send(post, :slug)&.to_s,
+        url:     build_url_for(post),
+        source:  'portalshit.net',
+        content: extract_plain_text_from_html(extract_html(post))
+      }
+    end
+
+    def compose_year_text(posts, delimiter: "\n---\n\n")
+      blocks = posts.map { |hash| compose_article_block(hash) }
+      return blocks.join("\n") if delimiter.nil?
+
+      blocks.join(delimiter)
+    end
+
+    def compose_article_block(hash)
+      <<~TXT
+      === ARTICLE START id:#{hash[:id]} ===
+      [published_at: #{hash[:date]}]
+      Title: #{hash[:title]}
+      URL: #{hash[:url]}
+      tags: #{Array(hash[:tags]).join(', ')}
+
+      #{hash[:content]}
+      TXT
+    end
+
+    def build_url_for(post)
+      candidate =
+        if post.respond_to?(:link) && post.link
+          post.link.to_s
+        elsif post.respond_to?(:slug) && post.slug
+          "/#{post.slug}"
+        else
+          "/posts/#{safe_send(post, :id)}"
+        end
+
+      safe_join_url(base_url, candidate)
+    end
+
+    private
+
+    def extract_html(post)
+      if post.respond_to?(:raw_body)
+        post.raw_body
+      elsif post.respond_to?(:body)
+        post.body.to_s
+      else
+        ''
+      end
+    end
+
+    def extract_plain_text_from_html(html_src)
+      html = html_src.to_s
+      html = html.gsub(/<\s*br\s*\/?>/i, "\n").gsub(/\u00A0/, ' ')
+      doc  = Nokogiri::HTML::DocumentFragment.parse(html)
+      text = doc.xpath('.//text()').map(&:text).join
+      text = CGI.unescapeHTML(text)
+      text = text.gsub(/\r\n?/, "\n").strip
+      text = text.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+      text = text.gsub(/[^\P{Cntrl}\t\n]/, '')
+      text
+    end
+
+    def extract_tags(post)
+      return [] unless post.respond_to?(:tags)
+
+      Array(post.tags).map do |tag|
+        tag.respond_to?(:name) ? tag.name : tag.to_s
+      end
+    end
+
+    def safe_send(object, method_name)
+      object.respond_to?(method_name) ? object.public_send(method_name) : nil
+    end
+
+    def safe_join_url(base, maybe_path)
+      return nil if base.to_s.empty? && maybe_path.to_s.empty?
+
+      path = maybe_path.to_s
+      if path.start_with?('http://', 'https://')
+        path
+      else
+        sanitized_base = base.to_s.sub(%r{/\z}, '')
+        path = "/#{path}" unless path.start_with?('/')
+        sanitized_base.empty? ? path : "#{sanitized_base}#{path}"
+      end
+    end
+  end
+end

--- a/lib/dify/chunking_config.rb
+++ b/lib/dify/chunking_config.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Dify
+  class ChunkingConfig
+    attr_reader :chunk_size, :delimiter
+
+    def initialize(chunk_size:, chunk_delimiter:, default_delimiter:, env: ENV)
+      @env = env
+      @default_delimiter = default_delimiter
+      @chunk_size = normalize_chunk_size(chunk_size)
+      @delimiter = normalize_delimiter(chunk_delimiter)
+    end
+
+    def process_rule
+      return nil if chunk_size.nil? && delimiter.nil?
+
+      segmentation = {}
+      if chunk_size
+        segmentation[:max_tokens] = chunk_size
+        segmentation[:chunk_overlap] = 150
+      end
+
+      if delimiter
+        segmentation[:separators] = [delimiter]
+        segmentation[:separator] = delimiter
+        segmentation[:strategy] = 'separator'
+      end
+
+      { mode: 'custom', rules: { pre_processing_rules: [], segmentation: segmentation } }
+    end
+
+    private
+
+    attr_reader :env, :default_delimiter
+
+    def normalize_chunk_size(value)
+      candidate = presence(value) ? value : env['CHUNK_SIZE']
+      return nil if candidate.nil?
+
+      candidate = candidate.to_i if candidate.respond_to?(:to_i)
+      candidate.positive? ? candidate : nil
+    end
+
+    def normalize_delimiter(value)
+      candidate = value
+      candidate = env['CHUNK_DELIMITER'] if candidate.nil?
+      candidate = default_delimiter if candidate.nil?
+      candidate = nil if candidate.is_a?(String) && candidate.empty?
+      candidate ||= default_delimiter
+      candidate
+    end
+
+    def presence(value)
+      case value
+      when nil then false
+      when String then !value.empty?
+      else true
+      end
+    end
+  end
+end

--- a/lib/dify/dataset_client.rb
+++ b/lib/dify/dataset_client.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+module Dify
+  class DatasetClient
+    attr_reader :api_base, :dataset_id, :dataset_token, :env
+
+    def initialize(api_base:, dataset_id:, dataset_token:, env: ENV)
+      @api_base = api_base
+      @dataset_id = dataset_id
+      @dataset_token = dataset_token
+      @env = env
+    end
+
+    def credentials_present?
+      dataset_id && dataset_token
+    end
+
+    def ensure_credentials!
+      raise 'ENV[DATASET_ID] not set' unless dataset_id
+      raise 'ENV[DATASET_API_KEY] not set' unless dataset_token
+    end
+
+    def create_document_by_text!(name:, text:, date: nil, process_rule: nil)
+      ensure_credentials!
+
+      response = http_post_json("/v1/datasets/#{dataset_id}/document/create-by-text", {
+        name: name,
+        text: text,
+        indexing_technique: 'high_quality',
+        process_rule: process_rule || { mode: 'automatic' }
+      })
+
+      body = JSON.parse(response.body) rescue {}
+      unless response.is_a?(Net::HTTPSuccess) && body.dig('document', 'id')
+        raise "create-by-text failed #{response.code} #{response.body}"
+      end
+
+      body.dig('document', 'id')
+    end
+
+    def update_document_by_text!(document_id:, name:, text:, process_rule: nil)
+      ensure_credentials!
+
+      response = http_post_json("/v1/datasets/#{dataset_id}/documents/#{document_id}/update_by_text", {
+        name: name,
+        text: text,
+        process_rule: process_rule || { mode: 'automatic' }
+      })
+
+      body = JSON.parse(response.body) rescue {}
+      unless response.is_a?(Net::HTTPSuccess) && body.dig('document', 'id')
+        raise "update_by_text failed #{response.code} #{response.body}"
+      end
+
+      body.dig('document', 'id')
+    end
+
+    def update_documents_metadata!(pairs)
+      ensure_credentials!
+      return if pairs.nil? || pairs.empty?
+
+      field_ids = {
+        'period' => (env['PERIOD_ID'] || env['METADATA_ID_PERIOD']),
+        'count'  => (env['COUNT_ID']  || env['METADATA_ID_COUNT'])
+      }.compact
+
+      operation_data = pairs.map do |pair|
+        metadata_list = pair.fetch(:metadata).filter_map do |key, value|
+          field_id = field_ids[key.to_s]
+          unless field_id && !field_id.empty?
+            warn "[metadata] skip key=#{key} (field id not configured)"
+            next
+          end
+
+          { id: field_id, name: key.to_s, value: value }
+        end
+
+        { document_id: pair.fetch(:document_id), metadata_list: metadata_list }
+      end
+
+      response = http_post_json("/v1/datasets/#{dataset_id}/documents/metadata", { operation_data: operation_data })
+      code = response.code.to_i
+      raise "metadata update failed #{response.code} #{response.body}" unless code == 202 || code == 200
+
+      response
+    end
+
+    def list_all_documents(page_size: 100)
+      ensure_credentials!
+
+      documents = []
+      page = 1
+
+      loop do
+        response = http_get("/v1/datasets/#{dataset_id}/documents", { page: page, limit: page_size })
+        body = JSON.parse(response.body) rescue {}
+        unless response.is_a?(Net::HTTPSuccess) && body['data'].is_a?(Array)
+          raise "list documents failed #{response.code} #{response.body}"
+        end
+
+        documents.concat(body['data'])
+        total = body['total'] || documents.size
+        break if documents.size >= total || body['data'].empty?
+
+        page += 1
+      end
+
+      documents
+    end
+
+    private
+
+    def http_get(path, query = {})
+      ensure_credentials!
+
+      uri = URI.join(api_base, path)
+      uri.query = URI.encode_www_form(query) unless query.empty?
+
+      request = Net::HTTP::Get.new(uri)
+      request['Authorization'] = "Bearer #{dataset_token}"
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.request(request)
+      end
+    end
+
+    def http_post_json(path, body_hash)
+      ensure_credentials!
+
+      uri = URI.join(api_base, path)
+      request = Net::HTTP::Post.new(uri)
+      request['Authorization'] = "Bearer #{dataset_token}"
+      request['Content-Type']  = 'application/json'
+      request.body = JSON.dump(body_hash)
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.request(request)
+      end
+    end
+  end
+end

--- a/lib/dify/knowledge_exporter.rb
+++ b/lib/dify/knowledge_exporter.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'date'
+require 'erb'
+
+require 'dify/dataset_client'
+require 'dify/article_collector'
+require 'dify/chunking_config'
+
+module Dify
+  class KnowledgeExporter
+    DEFAULT_SLEEP_SECS      = (ENV['SLEEP_SECS'] || '7').to_f
+    DEFAULT_RETRIES         = (ENV['RETRIES'] || '6').to_i
+    DEFAULT_CHUNK_DELIMITER = "\n---\n\n"
+
+    attr_reader :api_base, :dataset_id, :dataset_token, :base_url, :state_file,
+                :dataset_client, :article_collector, :env
+
+    def initialize(
+      api_base: ENV.fetch('DIFY_API_BASE', 'https://api.dify.ai'),
+      dataset_id: ENV['DATASET_ID'],
+      dataset_token: ENV['DATASET_API_KEY'],
+      base_url: (ENV['BASE_URL'] || '').sub(%r{/\z}, ''),
+      state_file: ENV['STATE_FILE'] || '.dify_uploaded_names',
+      env: ENV
+    )
+      @api_base = api_base
+      @dataset_id = dataset_id
+      @dataset_token = dataset_token
+      @base_url = base_url
+      @state_file = state_file
+      @env = env
+
+      @dataset_client = DatasetClient.new(
+        api_base: api_base,
+        dataset_id: dataset_id,
+        dataset_token: dataset_token,
+        env: env
+      )
+      @article_collector = ArticleCollector.new(base_url: base_url)
+    end
+
+    def credentials_present?
+      dataset_client.credentials_present?
+    end
+
+    def default_sleep_secs
+      DEFAULT_SLEEP_SECS
+    end
+
+    def default_retries
+      DEFAULT_RETRIES
+    end
+
+    def default_chunk_delimiter
+      DEFAULT_CHUNK_DELIMITER
+    end
+
+    def upload_yearly!(sleep_secs: nil, retries: nil, chunk_size: nil, chunk_delimiter: nil)
+      dataset_client.ensure_credentials!
+
+      sleep_secs = (sleep_secs || default_sleep_secs).to_f
+      retries    = (retries    || default_retries).to_i
+      chunking   = build_chunking_config(chunk_size: chunk_size, chunk_delimiter: chunk_delimiter)
+
+      rows = article_collector.collect(label: 'upload_yearly')
+      groups = rows.group_by { |h| (h[:date] || '').slice(0, 4) || 'unknown' }
+
+      done = if File.exist?(state_file)
+               File.readlines(state_file, chomp: true).to_set
+             else
+               Set.new
+             end
+
+      File.open(state_file, 'a') do |state|
+        batch = []
+        groups.sort.each do |year, items|
+          name = year
+          if done.include?(name)
+            puts "[upload_yearly] skip (done): #{name}"
+            next
+          end
+
+          text = article_collector.compose_year_text(items, delimiter: chunking.delimiter)
+          with_retry(retries) do
+            doc_id = dataset_client.create_document_by_text!(
+              name: name,
+              text: text,
+              date: "#{year}-01-01",
+              process_rule: chunking.process_rule
+            )
+            batch << { document_id: doc_id, metadata: { 'period' => year, 'count' => items.size } }
+            puts "[upload_yearly] ok #{name} (#{doc_id}) items=#{items.size}"
+          end
+
+          state.puts(name)
+          state.flush
+          sleep sleep_secs
+
+          next unless batch.size >= 10
+
+          dataset_client.update_documents_metadata!(batch)
+          batch.clear
+          sleep sleep_secs
+        rescue Interrupt
+          warn "[upload_yearly] interrupted by user"; raise
+        rescue => e
+          warn "[upload_yearly] skip #{name}: #{e.class} #{e.message}"
+        end
+
+        dataset_client.update_documents_metadata!(batch) unless batch.empty?
+      end
+
+      puts "[upload_yearly] done. state: #{state_file}"
+    end
+
+    def refresh_yearly!(sleep_secs: nil, retries: nil)
+      dataset_client.ensure_credentials!
+
+      sleep_secs = (sleep_secs || default_sleep_secs).to_f
+      retries    = (retries    || default_retries).to_i
+
+      rows = article_collector.collect(label: 'refresh_yearly')
+      groups = rows.group_by { |h| (h[:date] || '').slice(0, 4) || 'unknown' }
+
+      name2id = build_name_to_docid_map
+
+      batch = []
+      groups.sort.each do |year, items|
+        name = year
+        text = article_collector.compose_year_text(items)
+
+        doc_id = name2id[name]
+        if doc_id
+          with_retry(retries) do
+            dataset_client.update_document_by_text!(document_id: doc_id, name: name, text: text)
+            puts "[refresh_yearly] updated #{name} (#{doc_id}) items=#{items.size}"
+          end
+        else
+          with_retry(retries) do
+            doc_id = dataset_client.create_document_by_text!(
+              name: name,
+              text: text,
+              date: "#{year}-01-01",
+              process_rule: nil
+            )
+            name2id[name] = doc_id
+            puts "[refresh_yearly] created #{name} (#{doc_id}) items=#{items.size}"
+          end
+        end
+
+        batch << { document_id: doc_id, metadata: { 'period' => year, 'count' => items.size } }
+
+        if batch.size >= 10
+          with_retry(retries) { dataset_client.update_documents_metadata!(batch) }
+          batch.clear
+          sleep sleep_secs
+        end
+
+        sleep sleep_secs
+      rescue Interrupt
+        warn "[refresh_yearly] interrupted by user"; raise
+      rescue => e
+        warn "[refresh_yearly] skip #{name}: #{e.class} #{e.message}"
+      end
+
+      with_retry(retries) { dataset_client.update_documents_metadata!(batch) } unless batch.empty?
+
+      puts "[refresh_yearly] done."
+    end
+
+    def repair_year_metadata!(batch_size: nil)
+      dataset_client.ensure_credentials!
+
+      batch_size = (batch_size || 20).to_i
+
+      name2id = build_name_to_docid_map
+
+      counts = Hash.new(0)
+      Entry.published.includes(:tags, :category).find_each do |post|
+        y = (post.respond_to?(:created_at) ? post.created_at&.year : nil)
+        next unless y
+        y = y.to_s
+        counts[y] += 1 if y.match?(/\A\d{4}\z/)
+      end
+
+      missing = counts.keys.reject { |y| name2id.key?(y) }.sort
+      warn "[repair] WARNING: not found for years: #{missing.join(', ')}" unless missing.empty?
+
+      payloads = counts.sort.filter_map do |(year, cnt)|
+        doc_id = name2id[year]
+        next unless doc_id
+        { document_id: doc_id, metadata: { 'period' => year, 'count' => cnt } }
+      end
+
+      if payloads.empty?
+        puts "[repair] nothing to update"
+        return
+      end
+
+      payloads.each_slice(batch_size) do |slice|
+        res = dataset_client.update_documents_metadata!(slice)
+        puts "[repair] updated #{slice.size} docs (status=#{res.code})"
+        sleep 1.0
+      rescue => e
+        warn "[repair] slice failed: #{e.class} #{e.message}"
+      end
+
+      puts "[repair] done."
+    end
+
+    def update_year!(year:, sleep_secs: nil, retries: nil, chunk_size: nil, chunk_delimiter: nil)
+      dataset_client.ensure_credentials!
+
+      year       = (year || Time.now.year.to_s).to_s
+      sleep_secs = (sleep_secs || default_sleep_secs).to_f
+      retries    = (retries    || default_retries).to_i
+      chunking   = build_chunking_config(chunk_size: chunk_size, chunk_delimiter: chunk_delimiter)
+
+      name2id = build_name_to_docid_map
+      doc_id  = name2id[year]
+      raise "[update_year] document not found for year=#{year} (name must be exactly '#{year}')" unless doc_id
+
+      rows = article_collector.collect(label: 'update_year') do |post|
+        created_year = post.respond_to?(:created_at) ? post.created_at&.year&.to_s : nil
+        created_year == year
+      end
+
+      if rows.empty?
+        warn "[update_year] no posts found for year=#{year}; only metadata will be touched (count=0)"
+      end
+
+      new_text = article_collector.compose_year_text(rows, delimiter: chunking.delimiter)
+
+      with_retry(retries) do
+        dataset_client.update_document_by_text!(
+          document_id: doc_id,
+          name: year,
+          text: new_text,
+          process_rule: chunking.process_rule
+        )
+        puts "[update_year] updated body for #{year} (#{doc_id}) items=#{rows.size}"
+      end
+
+      payload = [{ document_id: doc_id, metadata: { 'period' => year, 'count' => rows.size } }]
+      with_retry(retries) do
+        dataset_client.update_documents_metadata!(payload)
+        puts "[update_year] updated metadata for #{year} (#{doc_id})"
+      end
+
+      sleep sleep_secs
+      puts "[update_year] done."
+    end
+
+    def popular_entries_report(limit: 20)
+      entries = Entry.popular(limit: limit)
+      template = <<~ERUBY
+        [period: recent_30d] [last_updated_at: <%= Date.today %>]
+
+        # Popular Entries (last 30 days)
+        <% entries.each.with_index(1) do |entry, i| %>
+          <%= i %>. <%= entry.title %> - <%= article_collector.build_url_for(entry) %>
+            published_at: <%= entry.created_at %>
+            blurb: <%= entry.summary %>
+            page_views: <%= entry.pv %>
+        <% end %>
+      ERUBY
+      erb = ERB.new(template)
+      erb.result(binding)
+    end
+
+    private
+
+    def build_chunking_config(chunk_size:, chunk_delimiter:)
+      ChunkingConfig.new(
+        chunk_size: chunk_size,
+        chunk_delimiter: chunk_delimiter,
+        default_delimiter: default_chunk_delimiter,
+        env: env
+      )
+    end
+
+    def build_name_to_docid_map
+      dataset_client.list_all_documents.each_with_object({}) do |document, map|
+        map[document['name'].to_s] = document['id']
+      end
+    end
+
+    def with_retry(retries)
+      tries = 0
+      begin
+        yield
+      rescue => e
+        tries += 1
+        raise e if tries > retries
+        backoff = (2**tries) * 0.5
+        warn "retry(#{tries}) after #{backoff}s: #{e.class} #{e.message}"
+        sleep backoff
+        retry
+      end
+    end
+  end
+end

--- a/lib/tasks/export_knowledge.rake
+++ b/lib/tasks/export_knowledge.rake
@@ -5,7 +5,6 @@ begin
 rescue LoadError
 end
 
-require 'set'
 require 'dify/knowledge_exporter'
 
 namespace :knowledge do

--- a/lib/tasks/export_knowledge.rake
+++ b/lib/tasks/export_knowledge.rake
@@ -6,7 +6,6 @@ rescue LoadError
 end
 
 require 'set'
-require 'erb'
 require 'dify/knowledge_exporter'
 
 namespace :knowledge do

--- a/lib/tasks/export_knowledge.rake
+++ b/lib/tasks/export_knowledge.rake
@@ -5,323 +5,22 @@ begin
 rescue LoadError
 end
 
-require 'json'
-require 'cgi'
-require 'net/http'
-require 'uri'
 require 'set'
-require 'nokogiri'
-require 'csv'
-require 'fileutils'
+require 'erb'
+require 'dify/knowledge_exporter'
 
-# =========================
-# 設定（ENV）
-# =========================
-DIFY_API_BASE      = ENV.fetch('DIFY_API_BASE', 'https://api.dify.ai')
-DIFY_DATASET_ID    = ENV['DATASET_ID']          # 必須（アップロード/修復時）
-DIFY_DATASET_TOKEN = ENV['DATASET_API_KEY']     # 必須（アップロード/修復時）
-BASE_URL           = (ENV['BASE_URL'] || '').sub(%r{/\z}, '')
-
-DEFAULT_SLEEP_SECS = (ENV['SLEEP_SECS'] || '7').to_f
-DEFAULT_RETRIES    = (ENV['RETRIES']    || '6').to_i
-STATE_FILE         = ENV['STATE_FILE']  || '.dify_uploaded_names'
-DEFAULT_CHUNK_DELIMITER = "\n---\n\n"
-
-# =========================
-# HTTP helpers
-# =========================
-def http_get(path, query = {})
-  raise 'ENV[DATASET_API_KEY] not set' unless DIFY_DATASET_TOKEN
-  uri = URI.join(DIFY_API_BASE, path)
-  uri.query = URI.encode_www_form(query) unless query.empty?
-  req = Net::HTTP::Get.new(uri)
-  req['Authorization'] = "Bearer #{DIFY_DATASET_TOKEN}"
-  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') { |h| h.request(req) }
-end
-
-def http_post_json(path, body_hash)
-  raise 'ENV[DATASET_API_KEY] not set' unless DIFY_DATASET_TOKEN
-  uri = URI.join(DIFY_API_BASE, path)
-  req = Net::HTTP::Post.new(uri)
-  req['Authorization'] = "Bearer #{DIFY_DATASET_TOKEN}"
-  req['Content-Type']  = 'application/json'
-  req.body = JSON.dump(body_hash)
-  Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') { |h| h.request(req) }
-end
-
-def with_retry(retries)
-  tries = 0
-  begin
-    yield
-  rescue => e
-    tries += 1
-    raise e if tries > retries
-    backoff = (2**tries) * 0.5 # 0.5,1,2,4,8,...
-    warn "retry(#{tries}) after #{backoff}s: #{e.class} #{e.message}"
-    sleep backoff
-    retry
-  end
-end
-
-# =========================
-# テキスト整形
-# =========================
-def safe_join_url(base, maybe_path)
-  return nil if base.to_s.empty? && maybe_path.to_s.empty?
-  path = maybe_path.to_s
-  if path.start_with?('http://', 'https://')
-    path
-  else
-    base = base.to_s.sub(%r{/\z}, '')
-    path = "/#{path}" unless path.start_with?('/')
-    base.empty? ? path : "#{base}#{path}"
-  end
-end
-
-def extract_plain_text_from_html(html_src)
-  html = html_src.to_s
-  html = html.gsub(/<\s*br\s*\/?>/i, "\n").gsub(/\u00A0/, ' ')
-  doc  = Nokogiri::HTML::DocumentFragment.parse(html)
-  text = doc.xpath('.//text()').map(&:text).join
-  text = CGI.unescapeHTML(text)
-  text = text.gsub(/\r\n?/, "\n").strip
-  text = text.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
-  text = text.gsub(/[^\P{Cntrl}\t\n]/, '')
-  text
-end
-
-def build_url_for(post)
-  candidate =
-    if post.respond_to?(:link) && post.link
-      post.link.to_s
-    elsif post.respond_to?(:slug) && post.slug
-      "/#{post.slug}"
-    else
-      "/posts/#{post.id}"
-    end
-  safe_join_url(BASE_URL, candidate)
-end
-
-def article_hash(post)
-  html = (post.respond_to?(:raw_body) ? post.raw_body : post.respond_to?(:body) ? post.body.to_s : '')
-  text = extract_plain_text_from_html(html)
-  tags = post.respond_to?(:tags) ? Array(post.tags).map { |t| t.respond_to?(:name) ? t.name : t.to_s } : []
-  {
-    id:      post.respond_to?(:id) ? post.id : nil,
-    title:   post.respond_to?(:title) ? post.title.to_s : '',
-    date:    (post.respond_to?(:created_at) ? post.created_at&.to_date&.to_s : nil),
-    tags:    tags,
-    slug:    (post.respond_to?(:slug) && post.slug ? post.slug.to_s : nil),
-    url:     build_url_for(post),
-    source:  'portalshit.net',
-    content: text
-  }
-end
-
-def compose_article_block(h)
-  <<~TXT
-  === ARTICLE START id:#{h[:id]} ===
-  [published_at: #{h[:date]}]
-  Title: #{h[:title]}
-  URL: #{h[:url]}
-  tags: #{Array(h[:tags]).join(', ')}
-
-  #{h[:content]}
-  TXT
-end
-
-def compose_year_text(posts_for_year, delimiter: DEFAULT_CHUNK_DELIMITER)
-  blocks = posts_for_year.map { |h| compose_article_block(h) }
-  return blocks.join("\n") if delimiter.nil?
-
-  blocks.join(delimiter)
-end
-
-def build_custom_process_rule(chunk_size:, delimiter:)
-  chunk_size = chunk_size.to_i if chunk_size
-  chunk_size = nil unless chunk_size.is_a?(Numeric) && chunk_size.positive?
-
-  delimiter = delimiter.to_s unless delimiter.nil?
-  delimiter = nil if delimiter.respond_to?(:empty?) && delimiter.empty?
-
-  return nil if chunk_size.nil? && delimiter.nil?
-
-  segmentation = {}
-  if chunk_size
-    segmentation[:max_tokens]    = chunk_size
-    segmentation[:chunk_overlap] = 150
-  end
-
-  if delimiter
-    segmentation[:separators] = [delimiter]
-    segmentation[:separator]  = delimiter
-    segmentation[:strategy]   = 'separator'
-  end
-
-  { mode: 'custom', rules: { pre_processing_rules: [], segmentation: segmentation } }
-end
-
-def resolve_chunk_options(args, size_key: :chunk_size, delimiter_key: :chunk_delimiter)
-  chunk_size = args[size_key]
-  chunk_size = ENV['CHUNK_SIZE'] if (chunk_size.nil? || chunk_size.to_s.empty?) && ENV['CHUNK_SIZE']
-  if chunk_size && !chunk_size.to_s.empty?
-    chunk_size = chunk_size.to_i
-    chunk_size = nil unless chunk_size.positive?
-  else
-    chunk_size = nil
-  end
-
-  chunk_delimiter = args[delimiter_key]
-  chunk_delimiter = ENV['CHUNK_DELIMITER'] if chunk_delimiter.nil?
-  chunk_delimiter = DEFAULT_CHUNK_DELIMITER if chunk_delimiter.nil?
-  chunk_delimiter = nil if chunk_delimiter.is_a?(String) && chunk_delimiter.empty?
-  chunk_delimiter ||= DEFAULT_CHUNK_DELIMITER
-
-  [chunk_size, chunk_delimiter]
-end
-
-# =========================
-# Dify Document ops
-# =========================
-def create_by_text!(name:, text:, date: nil, url: nil, process_rule: nil)
-  raise 'ENV[DATASET_ID] not set' unless DIFY_DATASET_ID
-  res  = http_post_json("/v1/datasets/#{DIFY_DATASET_ID}/document/create-by-text", {
-    name: name,
-    text: text,
-    indexing_technique: 'high_quality',
-    process_rule: process_rule || { mode: 'automatic' }
-  })
-  body = JSON.parse(res.body) rescue {}
-  unless res.is_a?(Net::HTTPSuccess) && body.dig('document','id')
-    raise "create-by-text failed #{res.code} #{res.body}"
-  end
-  body.dig('document','id')
-end
-
-def update_by_text!(document_id:, name:, text:, process_rule: nil)
-  res = http_post_json("/v1/datasets/#{DIFY_DATASET_ID}/documents/#{document_id}/update_by_text", {
-    name: name,
-    text: text,
-    process_rule: process_rule || { mode: 'automatic' }
-  })
-  body = JSON.parse(res.body) rescue {}
-  unless res.is_a?(Net::HTTPSuccess) && body.dig('document', 'id')
-    raise "update_by_text failed #{res.code} #{res.body}"
-  end
-  body.dig('document','id')
-end
-
-# pairs: [{ document_id: "uuid", metadata: { "period"=>"2005", "count"=>145, ... } }, ...]
-def update_documents_metadata!(pairs)
-  return if pairs.nil? || pairs.empty?
-
-  # Cloud 環境では field-list API を使わず、ENV に設定した ID だけで更新する
-  # 互換のため、旧ENV名(METADATA_ID_*) と新ENV名(PERIOD_ID/COUNT_ID)の両方を見る
-  field_ids = {
-    "period" => (ENV['PERIOD_ID'] || ENV['METADATA_ID_PERIOD']),
-    "count"  => (ENV['COUNT_ID']  || ENV['METADATA_ID_COUNT'])
-  }.compact
-
-  op = {
-    operation_data: pairs.map do |p|
-      metadata_list = p.fetch(:metadata).filter_map do |k, v|
-        fid = field_ids[k.to_s]
-        unless fid && !fid.empty?
-          warn "[metadata] skip key=#{k} (field id not configured)"
-          next
-        end
-        { id: fid, name: k.to_s, value: v }
-      end
-      { document_id: p.fetch(:document_id), metadata_list: metadata_list }
-    end
-  }
-
-  # 送る前に一度確認したければ↓を一時的に有効化
-  # puts JSON.pretty_generate(op)
-
-  res  = http_post_json("/v1/datasets/#{DIFY_DATASET_ID}/documents/metadata", op)
-  code = res.code.to_i
-  raise "metadata update failed #{res.code} #{res.body}" unless code == 202 || code == 200
-  res
-end
-
-def list_all_documents(dataset_id:, page_size: 100)
-  docs = []
-  page = 1
-  loop do
-    res  = http_get("/v1/datasets/#{dataset_id}/documents", { page: page, limit: page_size })
-    body = JSON.parse(res.body) rescue {}
-    raise "list documents failed #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess) && body['data'].is_a?(Array)
-    docs.concat(body['data'])
-    total = body['total'] || docs.size
-    break if docs.size >= total || body['data'].empty?
-    page += 1
-  end
-  docs
-end
-
-def build_name_to_docid_map
-  docs = list_all_documents(dataset_id: DIFY_DATASET_ID)
-  docs.each_with_object({}) { |d, m| m[d['name'].to_s] = d['id'] }
-end
-
-# =========================
-# Rake tasks（:environment 依存なし）
-# =========================
 namespace :knowledge do
   desc 'Upload posts grouped by year (one document per year)'
   task :upload_yearly, [:sleep_secs, :retries, :chunk_size, :chunk_delimiter] do |_, args|
-    abort '[upload_yearly] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless DIFY_DATASET_ID && DIFY_DATASET_TOKEN
-    sleep_secs = (args[:sleep_secs] || DEFAULT_SLEEP_SECS).to_f
-    retries    = (args[:retries]    || DEFAULT_RETRIES).to_i
-    chunk_size, chunk_delimiter = resolve_chunk_options(args)
-    process_rule = build_custom_process_rule(chunk_size: chunk_size, delimiter: chunk_delimiter)
+    exporter = Dify::KnowledgeExporter.new
+    abort '[upload_yearly] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless exporter.credentials_present?
 
-    rows = []
-    Entry.published.includes(:tags, :category).each do |post|
-      rows << article_hash(post)
-    rescue => e
-      warn "[upload_yearly] skip id=#{post.respond_to?(:id) ? post.id : 'n/a'}: #{e.class} #{e.message}"
-    end
-
-    groups = rows.group_by { |h| (h[:date] || '').slice(0, 4) || 'unknown' }
-
-    done = File.exist?(STATE_FILE) ? File.readlines(STATE_FILE, chomp: true).to_set : Set.new
-    File.open(STATE_FILE, 'a') do |state|
-      batch = []  # ← ここで初期化（NameError対策）
-      groups.sort.each do |year, items|
-        name = year
-        if done.include?(name)
-          puts "[upload_yearly] skip (done): #{name}"
-          next
-        end
-
-        text = compose_year_text(items, delimiter: chunk_delimiter)
-        with_retry(retries) do
-          doc_id = create_by_text!(name: name, text: text, date: "#{year}-01-01", url: nil, process_rule: process_rule)
-          # 年次メタは period/count を付与
-          batch << { document_id: doc_id, metadata: { 'period' => year, 'count' => items.size } }
-          puts "[upload_yearly] ok #{name} (#{doc_id}) items=#{items.size}"
-        end
-
-        state.puts(name); state.flush
-        sleep sleep_secs
-
-        if batch.size >= 10
-          update_documents_metadata!(batch)
-          batch.clear
-          sleep sleep_secs
-        end
-      rescue Interrupt
-        warn "[upload_yearly] interrupted by user"; raise
-      rescue => e
-        warn "[upload_yearly] skip #{name}: #{e.class} #{e.message}"
-      end
-
-      update_documents_metadata!(batch) unless batch.empty?
-    end
-
-    puts "[upload_yearly] done. state: #{STATE_FILE}"
+    exporter.upload_yearly!(
+      sleep_secs: args[:sleep_secs],
+      retries: args[:retries],
+      chunk_size: args[:chunk_size],
+      chunk_delimiter: args[:chunk_delimiter]
+    )
   end
 
   # 年次ドキュメントを update_by_text! で置換（無ければ create）
@@ -329,100 +28,21 @@ namespace :knowledge do
   #   DATASET_ID=... DATASET_API_KEY=... bundle exec rake "knowledge:refresh_yearly[1.2,6]"
   desc 'Refresh yearly documents (update_by_text; fallback to create if not exists)'
   task :refresh_yearly, [:sleep_secs, :retries] do |_, args|
-    abort '[refresh_yearly] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless DIFY_DATASET_ID && DIFY_DATASET_TOKEN
-    sleep_secs = (args[:sleep_secs] || DEFAULT_SLEEP_SECS).to_f
-    retries    = (args[:retries]    || DEFAULT_RETRIES).to_i
+    exporter = Dify::KnowledgeExporter.new
+    abort '[refresh_yearly] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless exporter.credentials_present?
 
-    # 1) 全記事を集めて年ごとにまとめる
-    rows = []
-    Entry.published.includes(:tags, :category).each do |post|
-      rows << article_hash(post)
-    rescue => e
-      warn "[refresh_yearly] skip id=#{post.respond_to?(:id) ? post.id : 'n/a'}: #{e.class} #{e.message}"
-    end
-    groups = rows.group_by { |h| (h[:date] || '').slice(0, 4) || 'unknown' }
-
-    # 2) 既存の name -> doc_id マップを取得（name は "YYYY" 想定）
-    name2id = build_name_to_docid_map
-
-    # 3) 年ごとに本文を再生成 → update_by_text（なければ create）
-    batch = []  # メタデータ一括更新用バッファ
-    groups.sort.each do |year, items|
-      name = year
-      text = compose_year_text(items)
-
-      doc_id = name2id[name]
-      if doc_id
-        with_retry(retries) do
-          update_by_text!(document_id: doc_id, name: name, text: text)
-          puts "[refresh_yearly] updated #{name} (#{doc_id}) items=#{items.size}"
-        end
-      else
-        with_retry(retries) do
-          doc_id = create_by_text!(name: name, text: text, date: "#{year}-01-01", url: nil)
-          name2id[name] = doc_id
-          puts "[refresh_yearly] created #{name} (#{doc_id}) items=#{items.size}"
-        end
-      end
-
-      # メタデータ（period / count）はまとめて付与（あなたの環境は id 必須実装）
-      batch << { document_id: doc_id, metadata: { 'period' => year, 'count' => items.size } }
-
-      # レート制限対策
-      if batch.size >= 10
-        with_retry(retries) { update_documents_metadata!(batch) }
-        batch.clear
-        sleep sleep_secs
-      end
-
-      sleep sleep_secs
-    rescue Interrupt
-      warn "[refresh_yearly] interrupted by user"; raise
-    rescue => e
-      warn "[refresh_yearly] skip #{name}: #{e.class} #{e.message}"
-    end
-
-    # 余り分のメタ更新
-    with_retry(retries) { update_documents_metadata!(batch) } unless batch.empty?
-
-    puts "[refresh_yearly] done."
+    exporter.refresh_yearly!(
+      sleep_secs: args[:sleep_secs],
+      retries: args[:retries]
+    )
   end
 
   desc 'Repair metadata (re-apply period/count by listing documents)'
   task :repair_year_metadata, [:batch_size] do |_, args|
-    abort '[repair_year_metadata] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless DIFY_DATASET_ID && DIFY_DATASET_TOKEN
-    batch_size = (args[:batch_size] || 20).to_i
+    exporter = Dify::KnowledgeExporter.new
+    abort '[repair_year_metadata] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless exporter.credentials_present?
 
-    name2id = build_name_to_docid_map
-
-    counts = Hash.new(0)
-    Entry.published.includes(:tags, :category).each do |post|
-      y = (post.respond_to?(:created_at) ? post.created_at&.year : nil)
-      next unless y
-      y = y.to_s
-      counts[y] += 1 if y.match?(/\A\d{4}\z/)
-    end
-
-    missing = counts.keys.reject { |y| name2id.key?(y) }.sort
-    warn "[repair] WARNING: not found for years: #{missing.join(', ')}" unless missing.empty?
-
-    payloads = counts.sort.filter_map do |(year, cnt)|
-      doc_id = name2id[year]
-      next unless doc_id
-      { document_id: doc_id, metadata: { 'period' => year, 'count' => cnt } }
-    end
-
-    if payloads.empty?
-      puts "[repair] nothing to update"; next
-    end
-
-    payloads.each_slice(batch_size) do |slice|
-      res = update_documents_metadata!(slice)
-      puts "[repair] updated #{slice.size} docs (status=#{res.code})"
-      sleep 1.0
-    end
-
-    puts "[repair] done."
+    exporter.repair_year_metadata!(batch_size: args[:batch_size])
   end
 
   # 年指定で1件だけ更新（本文置換＋メタ再付与）
@@ -430,70 +50,21 @@ namespace :knowledge do
   #   DATASET_ID=... DATASET_API_KEY=... bundle exec rake "knowledge:update_year[2025,1.2,6]"
   desc '年指定で1件だけドキュメントを更新'
   task :update_year, [:year, :sleep_secs, :retries, :chunk_size, :chunk_delimiter] do |_, args|
-    abort '[update_year] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless DIFY_DATASET_ID && DIFY_DATASET_TOKEN
+    exporter = Dify::KnowledgeExporter.new
+    abort '[update_year] require ENV[DATASET_ID], ENV[DATASET_API_KEY]' unless exporter.credentials_present?
 
-    year       = (args[:year] || Time.now.year.to_s).to_s
-    sleep_secs = (args[:sleep_secs] || DEFAULT_SLEEP_SECS).to_f
-    retries    = (args[:retries]    || DEFAULT_RETRIES).to_i
-    chunk_size, chunk_delimiter = resolve_chunk_options(args)
-    process_rule = build_custom_process_rule(chunk_size: chunk_size, delimiter: chunk_delimiter)
-
-    # 1) 「年 → doc_id」マップ（name を "YYYY" で作っている前提）
-    name2id = build_name_to_docid_map
-    doc_id  = name2id[year]
-    abort "[update_year] document not found for year=#{year} (name must be exactly '#{year}')" unless doc_id
-
-    # 2) その年の記事をDBから再収集
-    rows = []
-
-    Entry.published.includes(:tags, :category).each do |post|
-      h = article_hash(post)
-      next unless (h[:date] || '').start_with?(year)
-      rows << h
-    rescue => e
-      warn "[update_year] skip id=#{post.respond_to?(:id) ? post.id : 'n/a'}: #{e.class} #{e.message}"
-    end
-
-    if rows.empty?
-      warn "[update_year] no posts found for year=#{year}; only metadata will be touched (count=0)"
-    end
-
-    # 3) 年次テキストを再生成
-    new_text = compose_year_text(rows, delimiter: chunk_delimiter)
-
-    # 4) 本文置換（update_by_text）をリトライ付きで
-    with_retry(retries) do
-      update_by_text!(document_id: doc_id, name: year, text: new_text, process_rule: process_rule)
-      puts "[update_year] updated body for #{year} (#{doc_id}) items=#{rows.size}"
-    end
-
-    # 5) メタデータ(period/count) を operation_data（ID指定）で再付与
-    payload = [{ document_id: doc_id, metadata: { 'period' => year, 'count' => rows.size } }]
-    with_retry(retries) do
-      update_documents_metadata!(payload)
-      puts "[update_year] updated metadata for #{year} (#{doc_id})"
-    end
-
-    sleep sleep_secs
-    puts "[update_year] done."
+    exporter.update_year!(
+      year: args[:year],
+      sleep_secs: args[:sleep_secs],
+      retries: args[:retries],
+      chunk_size: args[:chunk_size],
+      chunk_delimiter: args[:chunk_delimiter]
+    )
   end
 
   desc 'Export popular entry'
   task :popular do
-    entries = Entry.popular(limit: 20)
-    text = <<~ERUBY
-      [period: recent_30d] [last_updated_at: <%= Date.today %>]
-
-      # Popular Entries (last 30 days)
-      <% entries.each.with_index(1) do |entry, i| %>
-        <%= i %>. <%= entry.title %> - <%= build_url_for(entry) %>
-          published_at: <%= entry.created_at %>
-          blurb: <%= entry.summary %>
-          page_views: <%= entry.pv %>
-      <% end %>
-    ERUBY
-    erb = ERB.new(text)
-    result = erb.result(binding)
-    puts result
+    exporter = Dify::KnowledgeExporter.new
+    puts exporter.popular_entries_report
   end
 end


### PR DESCRIPTION
## Summary
- extract a dedicated dataset client for Dify HTTP calls and metadata updates
- move article extraction and formatting into reusable collector/formatter classes
- slim KnowledgeExporter to orchestrate workflow and chunking configuration across the new collaborators

## Testing
- ruby -c lib/dify/dataset_client.rb
- ruby -c lib/dify/article_formatter.rb
- ruby -c lib/dify/article_collector.rb
- ruby -c lib/dify/chunking_config.rb
- ruby -c lib/dify/knowledge_exporter.rb
- ruby -c lib/tasks/export_knowledge.rake


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915d6d69c808321a59dd0cd70faa574)