### PR TITLE
Fix RSpec test suite: factory_bot migration and SQLite compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,12 +70,12 @@ end
 
 group :development, :test do
   gem 'database_cleaner-active_record'
-  gem 'factory_girl', '~> 4.0'
+  gem 'factory_bot', '~> 6.0'
   gem 'rack-test', require: 'rack/test'
   gem 'rspec', '~> 3.12'
   gem 'rspec-its'
   gem 'simplecov', require: false
-  gem 'sqlite3', '~> 1.4', group: :batch
+  gem 'sqlite3', '~> 1.4'
 end
 
 group :mysql do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,8 +149,8 @@ GEM
       activesupport (>= 5.2, < 9)
     exiftool (1.2.6)
       json
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
+    factory_bot (6.5.6)
+      activesupport (>= 6.1.0)
     faraday (1.10.4)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -460,7 +460,7 @@ DEPENDENCIES
   dotenv
   exception_notification (~> 4.5)
   exiftool
-  factory_girl (~> 4.0)
+  factory_bot (~> 6.0)
   faraday_middleware
   fastimage
   gpx (~> 1.1)

--- a/db/migration/20260206000000_create_activities.rb
+++ b/db/migration/20260206000000_create_activities.rb
@@ -2,7 +2,8 @@
 
 class CreateActivities < ActiveRecord::Migration[4.2]
   def change
-    create_table :activities, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :activities, **table_options do |t|
       t.references :entry, foreign_key: true, null: true
       t.references :user, foreign_key: true, null: false
 

--- a/db/migration/20260206000001_create_activity_data_points.rb
+++ b/db/migration/20260206000001_create_activity_data_points.rb
@@ -2,7 +2,8 @@
 
 class CreateActivityDataPoints < ActiveRecord::Migration[4.2]
   def change
-    create_table :activity_data_points, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :activity_data_points, **table_options do |t|
       t.references :activity, foreign_key: true, null: false
 
       t.integer  :elapsed_seconds

--- a/db/migration/20260208000000_remove_entry_id_from_activities.rb
+++ b/db/migration/20260208000000_remove_entry_id_from_activities.rb
@@ -2,7 +2,7 @@
 
 class RemoveEntryIdFromActivities < ActiveRecord::Migration[4.2]
   def change
-    remove_foreign_key :activities, :entries
+    remove_foreign_key :activities, :entries if connection.adapter_name =~ /Mysql/i
     remove_reference :activities, :entry
   end
 end

--- a/db/migration/20260308000001_create_entry_term_frequencies.rb
+++ b/db/migration/20260308000001_create_entry_term_frequencies.rb
@@ -2,7 +2,8 @@
 
 class CreateEntryTermFrequencies < ActiveRecord::Migration[4.2]
   def change
-    create_table :entry_term_frequencies, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :entry_term_frequencies, **table_options do |t|
       t.integer :entry_id, null: false
       t.string :term, null: false, limit: 255
       t.integer :term_count, null: false, default: 0

--- a/db/migration/20260308000002_replace_draft_with_publish_at.rb
+++ b/db/migration/20260308000002_replace_draft_with_publish_at.rb
@@ -3,13 +3,14 @@ class ReplaceDraftWithPublishAt < ActiveRecord::Migration[6.1]
     add_column :entries, :publish_at, :datetime, default: nil
     add_index :entries, :publish_at
     # 既存の公開済みエントリに publish_at を設定
-    execute("UPDATE entries SET publish_at = created_at WHERE draft = false")
+    execute("UPDATE entries SET publish_at = created_at WHERE draft = 0")
     remove_column :entries, :draft
   end
 
   def down
     add_column :entries, :draft, :boolean, default: false
-    execute("UPDATE entries SET draft = CASE WHEN publish_at IS NULL OR publish_at > NOW() THEN 1 ELSE 0 END")
+    now_func = connection.adapter_name =~ /Mysql/i ? 'NOW()' : "datetime('now')"
+    execute("UPDATE entries SET draft = CASE WHEN publish_at IS NULL OR publish_at > #{now_func} THEN 1 ELSE 0 END")
     remove_column :entries, :publish_at
   end
 end

--- a/db/migration/20260309000001_create_entry_embeddings.rb
+++ b/db/migration/20260309000001_create_entry_embeddings.rb
@@ -2,7 +2,8 @@
 
 class CreateEntryEmbeddings < ActiveRecord::Migration[6.0]
   def up
-    create_table :entry_embeddings, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :entry_embeddings, **table_options do |t|
       t.integer  :entry_id,         null: false
       t.json     :embedding,        null: false
       t.string   :model,            null: false, default: 'text-embedding-3-small'
@@ -17,7 +18,8 @@ class CreateEntryEmbeddings < ActiveRecord::Migration[6.0]
   def down
     drop_table :entry_embeddings
 
-    create_table :entry_term_frequencies, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :entry_term_frequencies, **table_options do |t|
       t.integer :entry_id,         null: false
       t.string  :term,             null: false, limit: 255
       t.integer :term_count,       null: false, default: 0

--- a/db/migration/20260314000001_create_entry_summaries.rb
+++ b/db/migration/20260314000001_create_entry_summaries.rb
@@ -2,7 +2,8 @@
 
 class CreateEntrySummaries < ActiveRecord::Migration[6.0]
   def change
-    create_table :entry_summaries, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' do |t|
+    table_options = connection.adapter_name =~ /Mysql/i ? { options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' } : {}
+    create_table :entry_summaries, **table_options do |t|
       t.integer :entry_id,     null: false
       t.text    :summary,      null: false
       t.string  :content_hash, null: false, limit: 64

--- a/lib/lokka/models/entry.rb
+++ b/lib/lokka/models/entry.rb
@@ -53,7 +53,11 @@ class Entry < ActiveRecord::Base
             tag_names = $1.split(",").map(&:strip)
             where(id: joins(:tags).where(tags: { name: tag_names }).select('entries.id'))
           else
-            where('MATCH (entries.title, entries.body) AGAINST (? in BOOLEAN MODE)', words)
+            if connection.adapter_name =~ /Mysql/i
+              where('MATCH (entries.title, entries.body) AGAINST (? in BOOLEAN MODE)', words)
+            else
+              where('entries.title LIKE :q OR entries.body LIKE :q', q: "%#{words}%")
+            end
           end
         }
 

--- a/public/admin/comments/form.haml
+++ b/public/admin/comments/form.haml
@@ -8,7 +8,7 @@
   .field
     = f.label :entry, caption: t('comment.entry')
     %br/
-    = text_field_tag :entry_title, value: @comment.entry.title, disabled: true
+    = text_field_tag :entry_title, value: @comment.entry&.title, disabled: true
   .field
     = f.label :name, caption: t('comment.name')
     %br/

--- a/public/plugin/lokka-amazon_associate/spec/factories.rb
+++ b/public/plugin/lokka-amazon_associate/spec/factories.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   create_time = update_time = Time.parse('2011-01-09T05:39:08Z')
 
   factory :user do
     sequence(:name) {|n| "testuser#{n}" }
-    hashed_password '6338db2314bba79531444996b780fa7036480733'
-    salt '2Z4H4DzATC'
-    permission_level 1
-    created_at create_time
-    updated_at update_time
+    hashed_password { '6338db2314bba79531444996b780fa7036480733' }
+    salt { '2Z4H4DzATC' }
+    permission_level { 1 }
+    created_at { create_time }
+    updated_at { update_time }
   end
 end

--- a/public/plugin/lokka-portalshit_patches/lib/lokka/portalshit_patches.rb
+++ b/public/plugin/lokka-portalshit_patches/lib/lokka/portalshit_patches.rb
@@ -13,6 +13,8 @@ end
 
 class Entry
   after_commit do
+    next if destroyed?
+
     Search.add(self) unless self.reload.draft?
   end
 

--- a/public/plugin/lokka-portalshit_patches/lib/lokka/portalshit_patches/helpers.rb
+++ b/public/plugin/lokka-portalshit_patches/lib/lokka/portalshit_patches/helpers.rb
@@ -9,6 +9,8 @@ module Lokka
     end
 
     def bread_crumb
+      return '' if @bread_crumbs.nil? || @bread_crumbs.empty?
+
       bread_crumb =
         @bread_crumbs[0..-2].each.with_index(1).
         inject('<ol itemscope itemtype="http://schema.org/BreadcrumbList">') do |html, (bread, index)|
@@ -52,7 +54,8 @@ module Lokka
     def not_found_candidates
       @not_found_candidates ||=
         begin
-          slugs = Entry.published.where.not('slug REGEXP ?', '^[0-9]+$').pluck(:slug)
+          all_slugs = Entry.published.where.not(slug: [nil, '']).pluck(:slug)
+          slugs = all_slugs.reject { |s| s.match?(/\A\d+\z/) }
           spell_checker = DidYouMean::SpellChecker.new(dictionary: slugs)
           current_slug = request.path_info.split('/').last
           slug_candidate = spell_checker.correct(current_slug)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,107 +1,109 @@
 # frozen_string_literal: true
 
-FactoryGirl.define do
+FactoryBot.define do
   create_time = update_time = Time.parse('2011-01-09T05:39:08Z')
   xmas = Time.parse('2011-12-25T19:00:00Z')
   newyear = Time.parse('2012-01-01T00:00:00Z')
 
   factory :site do
-    title 'Test Site'
-    description 'description...'
-    dashboard %q(<p>Welcome to Lokka!</p><p>To post a new article, choose "<a href=\"/admin/posts/new\">New</a>" under "Posts" on the menu to the left. To change the title of the site, choose "Settings" on the menu to the left. (The words displayed here can be changed anytime through the "<a href=\"/admin/site/edit\">Settings</a>" screen.)</p>)
-    theme 'jarvi'
-    created_at create_time
-    updated_at update_time
+    title { 'Test Site' }
+    description { 'description...' }
+    dashboard { %q(<p>Welcome to Lokka!</p><p>To post a new article, choose "<a href=\"/admin/posts/new\">New</a>" under "Posts" on the menu to the left. To change the title of the site, choose "Settings" on the menu to the left. (The words displayed here can be changed anytime through the "<a href=\"/admin/site/edit\">Settings</a>" screen.)</p>) }
+    theme { 'jarvi' }
+    created_at { create_time }
+    updated_at { update_time }
   end
 
   factory :user do
     sequence(:name) {|n| "testuser#{n}" }
     sequence(:email) {|n| "test_#{n}@test.com" }
-    password 'test'
-    password_confirmation 'test'
-    permission_level 1
+    password { 'test' }
+    password_confirmation { 'test' }
+    permission_level { 1 }
   end
 
   factory :post do
     association :user
-    title 'Test Post'
-    body '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>'
-    type 'Post'
-    created_at create_time
-    updated_at update_time
+    title { 'Test Post' }
+    body { '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>' }
+    type { 'Post' }
+    created_at { create_time }
+    updated_at { update_time }
+    publish_at { create_time }
 
     trait :kramdown do
-      title 'Markdown'
-      body "# hi! \nkramdown test"
-      markup 'kramdown'
+      title { 'Markdown' }
+      body { "# hi! \nkramdown test" }
+      markup { 'kramdown' }
     end
 
     trait :redcloth do
-      title 'Textile'
-      body "h1. hi!  \n\nredcloth test"
-      markup 'redcloth'
+      title { 'Textile' }
+      body { "h1. hi!  \n\nredcloth test" }
+      markup { 'redcloth' }
     end
   end
 
   factory :entry do
     association :user
     sequence(:title) {|n| "Test Post #{n}" }
-    body '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>'
-    type 'Post'
-    created_at create_time
-    updated_at update_time
+    body { '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>' }
+    type { 'Post' }
+    created_at { create_time }
+    updated_at { update_time }
+    publish_at { create_time }
   end
 
   factory :post_with_slug, parent: :post do
-    slug 'welcome-lokka'
+    slug { 'welcome-lokka' }
   end
 
   factory :later_post_with_slug, parent: :post do
-    title '1 day later'
-    body '1 day passed'
-    slug 'a-day-later'
-    created_at create_time + 1.days
-    updated_at update_time + 1.days
+    title { '1 day later' }
+    body { '1 day passed' }
+    slug { 'a-day-later' }
+    created_at { create_time + 1.days }
+    updated_at { update_time + 1.days }
   end
 
   factory :xmas_post, parent: :post do
-    created_at xmas
-    updated_at xmas
+    created_at { xmas }
+    updated_at { xmas }
   end
 
   factory :newyear_post, parent: :post do
-    created_at newyear
-    updated_at newyear
+    created_at { newyear }
+    updated_at { newyear }
   end
 
   factory :kramdown, parent: :post do
-    title 'Markdown'
-    body "# hi! \nkramdown test"
-    markup 'kramdown'
+    title { 'Markdown' }
+    body { "# hi! \nkramdown test" }
+    markup { 'kramdown' }
   end
 
   factory :redcloth, parent: :post do
-    title 'Textile'
-    body "h1. hi!  \n\nredcloth test"
-    markup 'redcloth'
+    title { 'Textile' }
+    body { "h1. hi!  \n\nredcloth test" }
+    markup { 'redcloth' }
   end
 
   factory :wikicloth, parent: :post do
-    title 'MediaWiki'
-    body "= hi! = \nmediawiki test"
-    markup 'wikicloth'
+    title { 'MediaWiki' }
+    body { "= hi! = \nmediawiki test" }
+    markup { 'wikicloth' }
   end
 
   factory :post_with_more, parent: :post do
-    body "a\n\n<!--more-->\n\nb\n\n<!--more-->\n\nc\n"
-    slug 'post-with-more'
-    markup 'kramdown'
+    body { "a\n\n<!--more-->\n\nb\n\n<!--more-->\n\nc\n" }
+    slug { 'post-with-more' }
+    markup { 'kramdown' }
   end
 
   factory :draft_post, parent: :post do
-    title 'Draft Post'
-    draft true
-    slug 'test-draft-post'
+    title { 'Draft Post' }
+    publish_at { nil }
+    slug { 'test-draft-post' }
   end
 
   factory :draft_post_with_tag_and_category, parent: :draft_post do
@@ -115,65 +117,65 @@ FactoryGirl.define do
 
   factory :tagging do
     association :tag
-    taggable_type 'Entry'
+    taggable_type { 'Entry' }
   end
 
   factory :snippet do
     sequence(:name) {|n| "Test Snippet#{n}" }
-    body 'Text for test snippet.'
-    created_at create_time
-    updated_at update_time
+    body { 'Text for test snippet.' }
+    created_at { create_time }
+    updated_at { update_time }
   end
 
   factory :page do
     association :user
     sequence(:title) {|n| "Test Page #{n}" }
-    body 'test Page'
-    type 'Page'
-    created_at create_time
-    updated_at update_time
+    body { 'test Page' }
+    type { 'Page' }
+    created_at { create_time }
+    updated_at { update_time }
+    publish_at { create_time }
   end
 
   factory :draft_page, parent: :page do
-    title 'Draft Page'
-    body 'draft Page'
+    title { 'Draft Page' }
+    body { 'draft Page' }
+    publish_at { nil }
   end
 
   factory :category do
     sequence(:title) {|n| "Test Category #{n}" }
     sequence(:slug)  {|n| "category-slug-#{n}" }
-    # created_at create_time
-    # updated_at update_time
   end
 
   factory :category_child, parent: :category do
-    title 'Test Child Category'
-    created_at create_time
-    updated_at update_time
+    title { 'Test Child Category' }
+    created_at { create_time }
+    updated_at { update_time }
   end
 
   # Comment has no association to entry by default
   factory :comment do
-    status Comment::APPROVED
-    name 'foobar'
-    email 'foobar@example.com'
-    body 'Test Comment'
-    created_at create_time
-    updated_at update_time
+    status { Comment::APPROVED }
+    name { 'foobar' }
+    email { 'foobar@example.com' }
+    body { 'Test Comment' }
+    created_at { create_time }
+    updated_at { update_time }
   end
 
   factory :spam_comment, class: Comment do
-    status Comment::SPAM
-    name 'spammer'
-    email 'spammer@example.com'
-    body 'Test Spam Comment'
-    created_at create_time
-    updated_at update_time
+    status { Comment::SPAM }
+    name { 'spammer' }
+    email { 'spammer@example.com' }
+    body { 'Test Spam Comment' }
+    created_at { create_time }
+    updated_at { update_time }
   end
 
   factory :field_name do
     sequence(:name) {|n| "Field Name #{n}" }
-    created_at create_time
-    updated_at update_time
+    created_at { create_time }
+    updated_at { update_time }
   end
 end

--- a/spec/integration/admin/comments_spec.rb
+++ b/spec/integration/admin/comments_spec.rb
@@ -37,7 +37,7 @@ describe '/admin/comments' do
       sample = attributes_for(:comment, entry_id: @post.id)
       post '/admin/comments', { comment: sample }
       last_response.should be_redirect
-      Post.find(@post.id).comments.should have(1).item
+      expect(Post.find(@post.id).comments.count).to eq(1)
     end
   end
 

--- a/spec/integration/admin/posts_spec.rb
+++ b/spec/integration/admin/posts_spec.rb
@@ -36,8 +36,8 @@ describe '/admin/posts' do
 
     Markup.engine_list.map(&:first).each do |markup|
       context "when #{markup} is set a default markup" do
-        before { Site.first.update_attributes(default_markup: markup) }
-        after { Site.first.update_attributes(default_markup: nil) }
+        before { Site.first.update(default_markup: markup) }
+        after { Site.first.update(default_markup: nil) }
 
         it "should select #{markup}" do
           get '/admin/posts/new'

--- a/spec/integration/admin/preview_spec.rb
+++ b/spec/integration/admin/preview_spec.rb
@@ -22,7 +22,7 @@ describe '/admin/preview' do
         expect(last_response).to be_successful
         expect(JSON.parse(last_response.body)['body']).to eq(
           <<~HTML
-            <h2>Dinner</h2>
+            <h2 id="dinner">Dinner</h2>
 
             <ol>
             <li>Ramen</li>

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -40,8 +40,8 @@ describe 'App' do
         end
 
         context 'change the number displayed on 5' do
-          before { Site.first.update_attributes(per_page: 5) }
-          after { Site.first.update_attributes(per_page: 10) }
+          before { Site.first.update(per_page: 5) }
+          after { Site.first.update(per_page: 10) }
 
           it 'should displayed 5' do
             subject.scan(regexp).size.should eq(5)
@@ -70,6 +70,7 @@ describe 'App' do
             check: 'check',
             comment: {
               name: 'lokka tarou',
+              email: 'tarou@example.com',
               homepage: 'http://www.example.com/',
               body: 'good entry!'
             }
@@ -78,7 +79,7 @@ describe 'App' do
 
         it 'should add a comment to an article' do
           post "/#{@post.id}", params
-          Comment.should have(1).item
+          expect(Comment.count).to eq(1)
         end
       end
     end
@@ -223,12 +224,13 @@ describe 'App' do
           check: 'check',
           comment: {
             name: 'lokka tarou',
+            email: 'tarou@example.com',
             homepage: 'http://www.example.com/',
             body: 'good entry!'
           }
         }
         post '/2011/01/09/welcome-lokka', params
-        Comment.should have(1).item
+        expect(Comment.count).to eq(1)
       end
     end
 

--- a/spec/integration/login_spec.rb
+++ b/spec/integration/login_spec.rb
@@ -13,7 +13,7 @@ describe 'Login' do
     end
 
     it 'should render login screen again' do
-      last_response.body.should match('<body class="admin_login">')
+      last_response.body.should match(/class=["']admin_login["']/)
     end
 
     it 'should not render dashboard side bar' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+ENV['RACK_ENV'] = 'test'
+ENV['LOKKA_ENV'] = 'test'
+
 require 'simplecov'
 
 SimpleCov.start do
@@ -19,7 +22,7 @@ require 'sinatra'
 require 'rack/test'
 require 'rspec'
 require 'rspec/its'
-require 'factory_girl'
+require 'factory_bot'
 require 'database_cleaner/active_record'
 require 'pry'
 
@@ -43,7 +46,7 @@ RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.include LokkaTestMethods
   config.include Lokka::Helpers
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/unit/category_spec.rb
+++ b/spec/unit/category_spec.rb
@@ -3,16 +3,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Category do
-  subject { Category }
-
   context 'on creating a new category with blank slug' do
     before { create :category }
-    it { should have(1).item }
+    it { expect(Category.count).to eq(1) }
   end
 
   context 'on creating 2 new categories with blank slug' do
     before { create_list :category, 2 }
-    subject { Category }
-    it { should have(2).item }
+    it { expect(Category.count).to eq(2) }
   end
 end

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -19,9 +19,9 @@ describe Lokka::EntryPreviewHandler do
       it 'Should respond HTML for body' do
         expect(result[:body]).to eq(
           <<~HTML
-            <h1>a</h1>
+            <h1 id="a">a</h1>
 
-            <h2>b</h2>
+            <h2 id="b">b</h2>
 
             <p>Test</p>
           HTML

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -12,7 +12,7 @@ describe Lokka::Helpers do
 
   describe 'months' do
     subject { months }
-    before  { create(:post, draft: true) }
+    before  { create(:post, publish_at: nil) }
 
     it { subject.count.should eq(0) }
   end
@@ -37,6 +37,7 @@ describe Lokka::PermalinkHelper do
 
   describe 'custom_permalink_fix' do
     it 'should return corrected URL by padding zero' do
+      create(:entry, created_at: '2011-01-09T23:45:45', slug: 'welcome')
       described_class.custom_permalink_fix('/2011/1/9/welcome').should eq('/2011/01/09/welcome')
     end
 

--- a/spec/unit/post_spec.rb
+++ b/spec/unit/post_spec.rb
@@ -156,7 +156,7 @@ describe Post do
 
     context 'When next post is not published' do
       before do
-        @next_post.update(draft: true)
+        @next_post.update(publish_at: nil)
       end
 
       it { is_expected.to eq(@latest_post) }
@@ -179,7 +179,7 @@ describe Post do
 
     context 'When prev post is not published' do
       before do
-        @prev_post.update(draft: true)
+        @prev_post.update(publish_at: nil)
       end
 
       it { is_expected.to eq(@oldest_post) }


### PR DESCRIPTION
## Summary
- **factory_girl → factory_bot ~> 6.0** に移行（ブロック構文への変換含む）
- テスト環境で **SQLite** を正しく使うように `spec_helper.rb` を修正（`ENV['RACK_ENV'] = 'test'` を冒頭に追加）
- マイグレーションファイルの **MySQL 固有オプション**（`ENGINE=InnoDB`、`REGEXP`、`NOW()`、`remove_foreign_key`）を adapter 判定で条件分岐
- `draft` → `publish_at` への移行に合わせてファクトリ・テストを更新
- 非推奨 API の修正（`update_attributes` → `update`、`have(N).items` → `expect(count).to eq(N)`）
- プロダクションコードのバグ修正:
  - `bread_crumb`: `@bread_crumbs` が nil のときのガード追加
  - `after_commit`: `destroyed?` チェック追加（削除時のクラッシュ回避）
  - `Entry.search`: SQLite 用の `LIKE` フォールバック追加
  - `not_found_candidates`: SQL の `REGEXP` を Ruby の正規表現に置換
  - `comments/form.haml`: `@comment.entry&.title` に safe navigation 追加

## Test plan
- [x] `bundle exec rspec` — 193 examples, 0 failures
- [ ] 本番環境の MySQL での動作確認（条件分岐が MySQL 側に影響しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)