### PR TITLE
Fix CircleCI config YAML formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     working_directory: ~/app
     docker:
       - image: morygonzalez/portalshit:latest
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
         environment:
           RAILS_ENV: test
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: /app
+    working_directory: ~/app
     docker:
       - image: morygonzalez/portalshit:latest
         auth:
@@ -19,7 +19,12 @@ jobs:
             bundle install -j1
       - run:
           name: Generate MeCab userdic
-          command: /app/docker-entrypoint.sh true
+          command: |
+            /usr/lib/mecab/mecab-dict-index \
+              -d /usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd \
+              -u lib/tokenizer/userdic.dic \
+              -f utf-8 -t utf-8 \
+              lib/tokenizer/userdic.csv
       - run:
           name: Database set up
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
             bundle config set without 'mysql postgresql'
             bundle install -j1
       - run:
+          name: Generate MeCab userdic
+          command: /app/docker-entrypoint.sh true
+      - run:
           name: Database set up
           command: |
             : > db/test.sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
       - run:
           command: |
             bundle config set path vendor/bundle
-            bundle install -j4 --without mysql postgresql
+            bundle config set without 'mysql postgresql'
+            bundle install -j4
       - save_cache:
           key: portalshit-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,25 +3,11 @@ jobs:
   build:
     working_directory: ~/app
     docker:
-      - image: cimg/ruby:3.2-node
+      - image: morygonzalez/portalshit:latest
         environment:
           RAILS_ENV: test
     steps:
-      - run:
-          name: Update bundler
-          command: gem install bundler:2.4.22
       - checkout
-      - restore_cache:
-          key: portalshit-{{ checksum "Gemfile.lock" }}
-      - run:
-          command: |
-            bundle config set path vendor/bundle
-            bundle config set without 'mysql postgresql'
-            bundle install -j1
-      - save_cache:
-          key: portalshit-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
       # - run:
       #     name: Database set up
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/app
+    working_directory: /app
     docker:
       - image: morygonzalez/portalshit:latest
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: |
             bundle config set path vendor/bundle
             bundle config set without 'mysql postgresql'
-            bundle install -j4
+            bundle install -j1
       - save_cache:
           key: portalshit-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,21 @@ jobs:
           RAILS_ENV: test
     steps:
       - checkout
-      # - run:
-      #     name: Database set up
-      #     command: |
-      #       : > db/test.sqlite3
-      #       RACK_ENV=test bundle exec rake db:migrate
-      # - run:
-      #     name: Run rspec
-      #     command: |
-      #       RACK_ENV=test bundle exec rspec --profile 10 \
-      #         --format progress \
-      #         $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      - run:
+          name: Bundle install
+          command: |
+            bundle config set path /usr/local/bundle
+            bundle config set without 'mysql postgresql'
+            bundle install -j1
+      - run:
+          name: Database set up
+          command: |
+            : > db/test.sqlite3
+            RACK_ENV=test bundle exec rake db:migrate
+      - run:
+          name: Run rspec
+          command: |
+            RACK_ENV=test bundle exec rspec --format progress
       - run:
           name: Deploy to production
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,10 @@ jobs:
       - checkout
       - restore_cache:
           key: portalshit-{{ checksum "Gemfile.lock" }}
-      - run: bundle install -j4 --path vendor/bundle --without mysql postgresql batch
+      - run:
+          command: |
+            bundle config set path vendor/bundle
+            bundle install -j4 --without mysql postgresql
       - save_cache:
           key: portalshit-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.env
 .bundle
 vendor/bundle
 db/database.yml

--- a/Gemfile.docker
+++ b/Gemfile.docker
@@ -174,12 +174,12 @@ end
 
 group :development, :test do
   gem 'database_cleaner-active_record'
-  gem 'factory_girl', '~> 4.0'
+  gem 'factory_bot', '~> 6.0'
   gem 'rack-test', require: 'rack/test'
   gem 'rspec', '~> 3.12'
   gem 'rspec-its'
   gem 'simplecov', require: false
-  gem 'sqlite3', '~> 1.4', group: :batch
+  gem 'sqlite3', '~> 1.4'
 end
 
 group :mysql do

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ unless Lokka.production?
 
     RSpec::Core::RakeTask.new(spec: 'spec:setup') do |t|
       t.pattern = 'spec/**/*_spec.rb'
-      t.rspec_opts = ['-cfs']
+      t.rspec_opts = ['--format', 'documentation']
     end
     namespace :spec do
       RSpec::Core::RakeTask.new(unit: 'spec:setup') do |t|

--- a/public/plugin/lokka-amazon_associate/Rakefile
+++ b/public/plugin/lokka-amazon_associate/Rakefile
@@ -6,7 +6,7 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec) do |spec|
     spec.pattern = 'spec/lib/*_spec.rb'
-    spec.rspec_opts = ['-cfs']
+    spec.rspec_opts = ['--format', 'documentation']
   end
 rescue LoadError => e
   warn e


### PR DESCRIPTION
## Summary
- `bundle install` ステップの YAML フォーマットを修正（`command` キーのインデント不足とマルチラインブロック `|` の欠落）
- 非推奨の `--path` フラグを `bundle config set path` に置き換え

## Test plan
- [ ] CircleCI のビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)