### PR TITLE
Add unit tests for 5 plugins

### DIFF
--- a/spec/unit/plugins/activity_tracker/statistics_calculator_spec.rb
+++ b/spec/unit/plugins/activity_tracker/statistics_calculator_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lokka::ActivityTracker::StatisticsCalculator do
+  def make_point(attrs = {})
+    { heart_rate: nil, speed: nil, cadence: nil, power: nil,
+      distance_meters: nil, altitude_meters: nil, elapsed_seconds: nil }.merge(attrs)
+  end
+
+  describe '#calculate_avg' do
+    it 'returns the average of the given field' do
+      points = [make_point(heart_rate: 120), make_point(heart_rate: 140), make_point(heart_rate: 160)]
+      calc = described_class.new(points)
+      expect(calc.calculate_avg(:heart_rate)).to eq(140.0)
+    end
+
+    it 'ignores nil values' do
+      points = [make_point(heart_rate: 100), make_point(heart_rate: nil), make_point(heart_rate: 200)]
+      calc = described_class.new(points)
+      expect(calc.calculate_avg(:heart_rate)).to eq(150.0)
+    end
+
+    it 'returns nil for empty data' do
+      calc = described_class.new([])
+      expect(calc.calculate_avg(:heart_rate)).to be_nil
+    end
+
+    it 'returns nil when all values are nil' do
+      points = [make_point(heart_rate: nil), make_point(heart_rate: nil)]
+      calc = described_class.new(points)
+      expect(calc.calculate_avg(:heart_rate)).to be_nil
+    end
+
+    it 'rounds to 2 decimal places' do
+      points = [make_point(speed: 3.0), make_point(speed: 4.0), make_point(speed: 5.0)]
+      calc = described_class.new(points)
+      expect(calc.calculate_avg(:speed)).to eq(4.0)
+    end
+
+    it 'works with string keys' do
+      points = [{ 'heart_rate' => 100 }, { 'heart_rate' => 200 }]
+      calc = described_class.new(points)
+      expect(calc.calculate_avg(:heart_rate)).to eq(150.0)
+    end
+  end
+
+  describe '#calculate_max' do
+    it 'returns the maximum value' do
+      points = [make_point(heart_rate: 120), make_point(heart_rate: 180), make_point(heart_rate: 150)]
+      calc = described_class.new(points)
+      expect(calc.calculate_max(:heart_rate)).to eq(180)
+    end
+
+    it 'returns nil for empty data' do
+      calc = described_class.new([])
+      expect(calc.calculate_max(:heart_rate)).to be_nil
+    end
+
+    it 'ignores nil values' do
+      points = [make_point(power: nil), make_point(power: 250), make_point(power: nil)]
+      calc = described_class.new(points)
+      expect(calc.calculate_max(:power)).to eq(250)
+    end
+  end
+
+  describe '#calculate_total_distance' do
+    it 'returns the maximum distance_meters (cumulative distance)' do
+      points = [
+        make_point(distance_meters: 0),
+        make_point(distance_meters: 1000),
+        make_point(distance_meters: 5000)
+      ]
+      calc = described_class.new(points)
+      expect(calc.calculate_total_distance).to eq(5000)
+    end
+
+    it 'returns nil when no distance data' do
+      points = [make_point, make_point]
+      calc = described_class.new(points)
+      expect(calc.calculate_total_distance).to be_nil
+    end
+  end
+
+  describe '#calculate_total_ascent' do
+    it 'sums only elevation gains' do
+      points = [
+        make_point(altitude_meters: 100),
+        make_point(altitude_meters: 150),
+        make_point(altitude_meters: 120),
+        make_point(altitude_meters: 200)
+      ]
+      calc = described_class.new(points)
+      # gain: 50 + 0 + 80 = 130
+      expect(calc.calculate_total_ascent).to eq(130.0)
+    end
+
+    it 'returns 0 when only descending' do
+      points = [
+        make_point(altitude_meters: 200),
+        make_point(altitude_meters: 150),
+        make_point(altitude_meters: 100)
+      ]
+      calc = described_class.new(points)
+      expect(calc.calculate_total_ascent).to eq(0.0)
+    end
+
+    it 'returns nil with fewer than 2 points' do
+      points = [make_point(altitude_meters: 100)]
+      calc = described_class.new(points)
+      expect(calc.calculate_total_ascent).to be_nil
+    end
+
+    it 'returns nil with no altitude data' do
+      points = [make_point, make_point, make_point]
+      calc = described_class.new(points)
+      expect(calc.calculate_total_ascent).to be_nil
+    end
+  end
+
+  describe '#calculate_duration' do
+    it 'returns the maximum elapsed_seconds' do
+      points = [
+        make_point(elapsed_seconds: 0),
+        make_point(elapsed_seconds: 600),
+        make_point(elapsed_seconds: 1800)
+      ]
+      calc = described_class.new(points)
+      expect(calc.calculate_duration).to eq(1800)
+    end
+
+    it 'returns nil when no elapsed data' do
+      calc = described_class.new([make_point])
+      expect(calc.calculate_duration).to be_nil
+    end
+  end
+
+  describe '#heart_rate_zones' do
+    let(:points) do
+      # max_hr = 200, zones: z1(100-120), z2(120-140), z3(140-160), z4(160-180), z5(180-200)
+      [
+        make_point(heart_rate: 110),  # zone1
+        make_point(heart_rate: 130),  # zone2
+        make_point(heart_rate: 150),  # zone3
+        make_point(heart_rate: 170),  # zone4
+        make_point(heart_rate: 190)   # zone5
+      ]
+    end
+    let(:calc) { described_class.new(points) }
+
+    it 'distributes HR values into 5 zones' do
+      result = calc.heart_rate_zones(200)
+      expect(result.keys).to match_array(%i[zone1 zone2 zone3 zone4 zone5])
+      expect(result[:zone1]).to eq(20.0)
+      expect(result[:zone2]).to eq(20.0)
+      expect(result[:zone3]).to eq(20.0)
+      expect(result[:zone4]).to eq(20.0)
+      expect(result[:zone5]).to eq(20.0)
+    end
+
+    it 'returns nil when max_hr is nil' do
+      expect(calc.heart_rate_zones(nil)).to be_nil
+    end
+
+    it 'returns nil when no HR data' do
+      calc = described_class.new([make_point, make_point])
+      expect(calc.heart_rate_zones(200)).to be_nil
+    end
+
+    it 'handles boundary values' do
+      # HR exactly at zone boundary (120 = 0.6 * 200) belongs to both zone1 and zone2
+      points = [make_point(heart_rate: 120)]
+      calc = described_class.new(points)
+      result = calc.heart_rate_zones(200)
+      expect(result[:zone1]).to eq(100.0)
+      expect(result[:zone2]).to eq(100.0)
+    end
+  end
+
+  describe '#pace_per_km' do
+    it 'calculates pace for each km split' do
+      points = [
+        make_point(distance_meters: 0, elapsed_seconds: 0),
+        make_point(distance_meters: 500, elapsed_seconds: 150),
+        make_point(distance_meters: 1000, elapsed_seconds: 300),
+        make_point(distance_meters: 1500, elapsed_seconds: 450),
+        make_point(distance_meters: 2000, elapsed_seconds: 600)
+      ]
+      calc = described_class.new(points)
+      result = calc.pace_per_km
+
+      expect(result.length).to eq(2)
+      expect(result[0][:km]).to eq(1)
+      expect(result[0][:pace_seconds]).to eq(300) # 300s for 1000m
+      expect(result[1][:km]).to eq(2)
+      expect(result[1][:pace_seconds]).to eq(300)
+    end
+
+    it 'includes final partial split when >= 100m remaining' do
+      points = [
+        make_point(distance_meters: 0, elapsed_seconds: 0),
+        make_point(distance_meters: 1000, elapsed_seconds: 300),
+        make_point(distance_meters: 1500, elapsed_seconds: 450)
+      ]
+      calc = described_class.new(points)
+      result = calc.pace_per_km
+
+      expect(result.length).to eq(2)
+      expect(result[1][:fraction]).to eq(0.5)
+    end
+
+    it 'excludes final partial split when < 100m remaining' do
+      points = [
+        make_point(distance_meters: 0, elapsed_seconds: 0),
+        make_point(distance_meters: 1000, elapsed_seconds: 300),
+        make_point(distance_meters: 1050, elapsed_seconds: 315)
+      ]
+      calc = described_class.new(points)
+      result = calc.pace_per_km
+
+      expect(result.length).to eq(1)
+    end
+
+    it 'returns empty array with fewer than 2 points' do
+      points = [make_point(distance_meters: 0, elapsed_seconds: 0)]
+      calc = described_class.new(points)
+      expect(calc.pace_per_km).to eq([])
+    end
+
+    it 'returns empty array with no distance/time data' do
+      calc = described_class.new([make_point, make_point])
+      expect(calc.pace_per_km).to eq([])
+    end
+  end
+
+  describe '#calculate' do
+    it 'returns a hash with all statistics' do
+      points = [
+        make_point(heart_rate: 120, speed: 3.0, cadence: 80, power: 200,
+                   distance_meters: 0, altitude_meters: 100, elapsed_seconds: 0),
+        make_point(heart_rate: 160, speed: 4.0, cadence: 90, power: 300,
+                   distance_meters: 5000, altitude_meters: 200, elapsed_seconds: 1800)
+      ]
+      calc = described_class.new(points)
+      result = calc.calculate
+
+      expect(result[:avg_heart_rate]).to eq(140.0)
+      expect(result[:max_heart_rate]).to eq(160)
+      expect(result[:avg_speed]).to eq(3.5)
+      expect(result[:max_speed]).to eq(4.0)
+      expect(result[:avg_cadence]).to eq(85.0)
+      expect(result[:avg_power]).to eq(250.0)
+      expect(result[:max_power]).to eq(300)
+      expect(result[:total_distance_meters]).to eq(5000)
+      expect(result[:total_ascent_meters]).to eq(100.0)
+      expect(result[:duration_seconds]).to eq(1800)
+    end
+  end
+end

--- a/spec/unit/plugins/ng_words_spec.rb
+++ b/spec/unit/plugins/ng_words_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'NgWords helpers' do
+  include Lokka::Helpers
+
+  describe '#ng_words' do
+    it 'parses comma-separated words' do
+      allow(Option).to receive(:ng_words).and_return('spam, viagra, casino')
+      expect(ng_words).to eq(%w[spam viagra casino])
+    end
+
+    it 'returns empty array when nil' do
+      allow(Option).to receive(:ng_words).and_return(nil)
+      expect(ng_words).to eq([])
+    end
+  end
+
+  describe '#ok_languages' do
+    it 'parses comma-separated language codes' do
+      allow(Option).to receive(:ok_languages).and_return('en, ja')
+      expect(ok_languages).to eq(%w[en ja])
+    end
+
+    it 'returns empty array when nil' do
+      allow(Option).to receive(:ok_languages).and_return(nil)
+      expect(ok_languages).to eq([])
+    end
+  end
+
+  describe '#include_ng_words?' do
+    before do
+      allow(Option).to receive(:ng_words).and_return('spam, viagra')
+    end
+
+    it 'returns true when body contains an NG word' do
+      allow(self).to receive(:comment_body).and_return('Buy cheap viagra now')
+      expect(include_ng_words?).to be true
+    end
+
+    it 'is case insensitive' do
+      allow(self).to receive(:comment_body).and_return('SPAM message')
+      expect(include_ng_words?).to be true
+    end
+
+    it 'returns false when body has no NG words' do
+      allow(self).to receive(:comment_body).and_return('Hello, nice post!')
+      expect(include_ng_words?).to be false
+    end
+
+    it 'returns false with empty NG word list' do
+      allow(Option).to receive(:ng_words).and_return(nil)
+      allow(self).to receive(:comment_body).and_return('anything')
+      expect(include_ng_words?).to be false
+    end
+  end
+
+  describe '#other_than_ok_language?' do
+    before do
+      allow(Option).to receive(:ok_languages).and_return('en, ja')
+    end
+
+    it 'returns false when language is in OK list' do
+      allow(CLD).to receive(:detect_language).and_return({ code: 'en' })
+      allow(self).to receive(:comment_body).and_return('Hello world')
+      expect(other_than_ok_language?).to be false
+    end
+
+    it 'returns true when language is not in OK list' do
+      allow(CLD).to receive(:detect_language).and_return({ code: 'ru' })
+      allow(self).to receive(:comment_body).and_return('Привет мир')
+      expect(other_than_ok_language?).to be true
+    end
+  end
+
+  describe '#is_it_spam?' do
+    before do
+      allow(Option).to receive(:ng_words).and_return('spam')
+      allow(Option).to receive(:ok_languages).and_return('en, ja')
+    end
+
+    it 'returns true when body contains NG words' do
+      allow(self).to receive(:comment_body).and_return('This is spam')
+      allow(CLD).to receive(:detect_language).and_return({ code: 'en' })
+      expect(is_it_spam?).to be true
+    end
+
+    it 'returns true when language is not OK' do
+      allow(self).to receive(:comment_body).and_return('Clean text')
+      allow(CLD).to receive(:detect_language).and_return({ code: 'ru' })
+      expect(is_it_spam?).to be true
+    end
+
+    it 'returns false when clean and OK language' do
+      allow(self).to receive(:comment_body).and_return('Nice post!')
+      allow(CLD).to receive(:detect_language).and_return({ code: 'en' })
+      expect(is_it_spam?).to be false
+    end
+  end
+end

--- a/spec/unit/plugins/portalshit_patches/entry_patches_spec.rb
+++ b/spec/unit/plugins/portalshit_patches/entry_patches_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Entry portalshit_patches' do
+  let(:entry) { create(:post) }
+
+  describe '#long_body_with_figure' do
+    it 'wraps root-level img in figure' do
+      entry.update(body: '<img src="test.jpg">')
+      # Reset memoized value
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_body_with_figure
+      expect(result).to include('<figure>')
+      expect(result).to include('test.jpg')
+    end
+
+    it 'converts title attribute to figcaption' do
+      entry.update(body: '<img src="test.jpg" title="My Caption">')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_body_with_figure
+      expect(result).to include('<figcaption>My Caption</figcaption>')
+    end
+
+    it 'does not add figcaption when no title' do
+      entry.update(body: '<img src="test.jpg">')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_body_with_figure
+      expect(result).not_to include('<figcaption>')
+    end
+
+    it 'replaces p parent when img is only child' do
+      entry.update(body: '<p><img src="test.jpg"></p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_body_with_figure
+      expect(result).to include('<figure>')
+      expect(result).not_to match(%r{<p>\s*<figure>})
+    end
+  end
+
+  describe '#long_description' do
+    it 'strips HTML tags' do
+      entry.update(body: '<p>Hello <strong>world</strong></p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_description
+      expect(result).to include('Hello world')
+      expect(result).not_to include('<p>')
+      expect(result).not_to include('<strong>')
+    end
+
+    it 'removes figcaption content' do
+      entry.update(body: '<figure><img src="x.jpg"><figcaption>Caption</figcaption></figure><p>Text</p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_description
+      expect(result).not_to include('Caption')
+      expect(result).to include('Text')
+    end
+
+    it 'truncates at the specified limit' do
+      long_text = 'a' * 200
+      entry.update(body: "<p>#{long_text}</p>")
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      result = entry.long_description(50)
+      # limit is 0-indexed slice, so 51 chars + "..."
+      expect(result.length).to be <= 55
+      expect(result).to end_with('...')
+    end
+  end
+
+  describe '#body_with_toc' do
+    it 'replaces <!-- toc --> marker with table of contents' do
+      entry.update(markup: 'redcarpet', body: "<!-- toc -->\n\n## Heading One\n\nContent\n\n## Heading Two\n\nMore content")
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@toc, nil)
+      result = entry.body_with_toc
+      expect(result).to include('Table of Contents')
+    end
+
+    it 'returns body unchanged when no toc marker' do
+      entry.update(body: '<p>No toc here</p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@toc, nil)
+      result = entry.body_with_toc
+      expect(result).not_to include('Table of Contents')
+    end
+  end
+
+  describe '#images' do
+    it 'extracts img src attributes' do
+      entry.update(body: '<img src="a.jpg"><img src="b.png">')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@images, nil)
+      expect(entry.images).to include('a.jpg', 'b.png')
+    end
+
+    it 'extracts video poster attributes' do
+      entry.update(body: '<p><video poster="thumb.jpg" src="video.mp4"></video></p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@images, nil)
+      expect(entry.images).to include('thumb.jpg')
+    end
+  end
+
+  describe '#cover_image' do
+    it 'returns first image when it is jpg/png/gif' do
+      entry.update(body: '<img src="photo.jpg">')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@images, nil)
+      expect(entry.cover_image).to eq('photo.jpg')
+    end
+
+    it 'returns default image for non-standard formats' do
+      entry.update(body: '<img src="photo.webp">')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@images, nil)
+      expect(entry.cover_image).to eq('https://portalshit.net/theme/portalshit/ogp_image.png')
+    end
+
+    it 'returns default image when no images' do
+      entry.update(body: '<p>No images</p>')
+      entry.instance_variable_set(:@long_body_with_figure, nil)
+      entry.instance_variable_set(:@images, nil)
+      expect(entry.cover_image).to eq('https://portalshit.net/theme/portalshit/ogp_image.png')
+    end
+  end
+end

--- a/spec/unit/plugins/portalshit_patches/search_spec.rb
+++ b/spec/unit/plugins/portalshit_patches/search_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Search do
+  describe '#search_type' do
+    it 'returns :tag for tag: prefix' do
+      expect(Search.new('tag:ruby').search_type).to eq(:tag)
+    end
+
+    it 'returns :tag for tags: prefix' do
+      expect(Search.new('tags:ruby,rails').search_type).to eq(:tag)
+    end
+
+    it 'returns :category for category: prefix' do
+      expect(Search.new('category:tech').search_type).to eq(:category)
+    end
+
+    it 'returns :all for plain text' do
+      expect(Search.new('hello world').search_type).to eq(:all)
+    end
+  end
+
+  describe '#query_type' do
+    it 'returns :term_query for tag without spaces' do
+      expect(Search.new('tag:ruby').query_type).to eq(:term_query)
+    end
+
+    it 'returns :phrase_query for tag with spaces' do
+      expect(Search.new('tag:ruby on rails').query_type).to eq(:phrase_query)
+    end
+
+    it 'returns :phrase_query for tags with spaces' do
+      expect(Search.new('tags:ruby, rails').query_type).to eq(:phrase_query)
+    end
+
+    it 'returns :facet_query for category' do
+      expect(Search.new('category:tech').query_type).to eq(:facet_query)
+    end
+
+    it 'returns :smart_query for plain text' do
+      expect(Search.new('hello world').query_type).to eq(:smart_query)
+    end
+  end
+
+  describe '#keywords' do
+    context 'tag search' do
+      it 'splits by comma and lowercases' do
+        search = Search.new('tag:Ruby,Rails,JS')
+        expect(search.keywords).to eq(%w[ruby rails js])
+      end
+
+      it 'strips whitespace from tag names' do
+        search = Search.new('tags:ruby , rails')
+        expect(search.keywords).to eq(%w[ruby rails])
+      end
+
+      it 'returns empty array when no tags after prefix' do
+        search = Search.new('tag:')
+        expect(search.keywords).to eq([])
+      end
+    end
+
+    context 'category search' do
+      it 'prepends / to category name' do
+        search = Search.new('category:tech')
+        expect(search.keywords).to eq(['/tech'])
+      end
+    end
+
+    context 'full text search' do
+      it 'tokenizes query via Tokenizer' do
+        allow(Tokenizer).to receive(:run).with('hello world').and_return(%w[hello world])
+        search = Search.new('hello world')
+        expect(search.keywords).to eq(['hello world'])
+      end
+
+      it 'falls back to raw query when tokenizer returns empty' do
+        allow(Tokenizer).to receive(:run).with('test').and_return([])
+        search = Search.new('test')
+        expect(search.keywords).to eq(['test'])
+      end
+
+      it 'strips quotes from raw query fallback' do
+        allow(Tokenizer).to receive(:run).with('"exact phrase"').and_return([])
+        search = Search.new('"exact phrase"')
+        expect(search.keywords).to eq(['exact phrase'])
+      end
+    end
+  end
+
+  describe '#fields' do
+    it 'returns :tags for tag search' do
+      expect(Search.new('tag:ruby').fields).to eq(:tags)
+    end
+
+    it 'returns :category for category search' do
+      expect(Search.new('category:tech').fields).to eq(:category)
+    end
+
+    it 'returns multiple fields for full text search' do
+      expect(Search.new('hello').fields).to eq(%i[title title_tokenized body category_tokenized tags])
+    end
+  end
+end

--- a/spec/unit/plugins/rouge_spec.rb
+++ b/spec/unit/plugins/rouge_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Entry syntax_highlight' do
+  let(:entry) { build(:post) }
+
+  describe '#syntax_highlight' do
+    it 'highlights code with language specified on pre tag' do
+      html = '<pre class="ruby"><code>puts "hello"</code></pre>'
+      result = entry.syntax_highlight(html)
+      expect(result).to include('highlight')
+      expect(result).to include('<div class="highlight">')
+    end
+
+    it 'highlights code with language specified on code tag' do
+      html = '<pre><code class="ruby">puts "hello"</code></pre>'
+      result = entry.syntax_highlight(html)
+      expect(result).to include('highlight')
+    end
+
+    it 'auto-detects language when no class specified' do
+      html = '<pre><code>#!/bin/bash
+echo "hello"</code></pre>'
+      result = entry.syntax_highlight(html)
+      expect(result).to include('highlight')
+    end
+
+    it 'leaves content without pre tags unchanged' do
+      html = '<p>No code here</p>'
+      result = entry.syntax_highlight(html)
+      expect(result).to eq('<p>No code here</p>')
+    end
+
+    it 'skips highlighting on error (unknown language)' do
+      html = '<pre class="nonexistent_language_xyz"><code>some code</code></pre>'
+      result = entry.syntax_highlight(html)
+      # Should not raise, may leave as-is or highlight depending on Rouge behavior
+      expect(result).to be_a(String)
+    end
+
+    it 'handles multiple pre blocks' do
+      html = '<pre class="ruby"><code>puts 1</code></pre><pre class="python"><code>print(1)</code></pre>'
+      result = entry.syntax_highlight(html)
+      expect(result.scan('highlight').length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- テストがなかった5つのプラグインにユニットテストを追加（合計79テスト）
  - `lokka-activity_tracker` StatisticsCalculator: 平均・最大・距離・上昇量・HR ゾーン・ペース計算（27件）
  - `lokka-portalshit_patches` Entry パッチ: figure 変換・description・TOC・画像抽出・カバー画像（14件）
  - `lokka-portalshit_patches` Search: search_type・query_type・keywords・fields 判定（19件）
  - `lokka-rouge`: シンタックスハイライト（6件）
  - `lokka-ng_words`: スパム判定・NG ワード・言語チェック（13件）

## Test plan
- [x] `bundle exec rspec spec/unit/plugins/` で全79テストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)