### PR TITLE
Fix UTF-8 encoding error for Japanese URL paths

### DIFF
--- a/lib/lokka/helpers/helpers.rb
+++ b/lib/lokka/helpers/helpers.rb
@@ -102,7 +102,7 @@ module Lokka
     def request_path
       path = '/' + request.url.split('/')[3..-1].join('/')
       path += '/' if path != '/' && request.url =~ %r{/$}
-      path.encode('UTF-8')
+      path.force_encoding('UTF-8')
     end
 
     def canonical_url


### PR DESCRIPTION
Use force_encoding('UTF-8') instead of encode('UTF-8') to handle
request paths containing multibyte characters (e.g. /tags/サーバー).
The path bytes are already valid UTF-8 but labeled as ASCII-8BIT,
so re-labeling the encoding is sufficient.

https://claude.ai/code/session_013s2Vi9bG6W7KcjJcyWUvb2