### PR TITLE
Show hourly averages on server metrics dashboard, hide disk columns

### DIFF
--- a/lib/lokka/app/admin/server_metrics.rb
+++ b/lib/lokka/app/admin/server_metrics.rb
@@ -24,7 +24,26 @@ module Lokka
         halt 404 if filtered.empty?
 
         content_type 'text/tab-separated-values'
-        [header, *filtered].join("\n") + "\n"
+
+        if params[:raw]
+          return [header, *filtered].join("\n") + "\n"
+        end
+
+        # Aggregate to hourly averages
+        headers = header.split("\t")
+        numeric_indices = (1...headers.length).to_a
+
+        hourly_groups = filtered.group_by { |line| line[0, 13] } # "2026-03-19T14"
+        averaged = hourly_groups.map do |hour_prefix, rows|
+          columns = rows.map { |r| r.split("\t") }
+          avg = numeric_indices.map do |i|
+            values = columns.map { |c| c[i].to_f }
+            (values.sum / values.size).round(2)
+          end
+          [hour_prefix + ':00', *avg].join("\t")
+        end
+
+        [header, *averaged].join("\n") + "\n"
       end
     end
   end

--- a/public/_dashboard_snippet.html
+++ b/public/_dashboard_snippet.html
@@ -175,30 +175,28 @@
     swap_total_mb: 'Swap Total', swap_used_mb: 'Swap Used',
     disk_used_gb: 'Disk Used', disk_avail_gb: 'Disk Avail', disk_use_pct: 'Disk%'
   };
+  const hiddenColumns = new Set(['disk_used_gb', 'disk_avail_gb', 'disk_use_pct']);
 
   const buildMetricsTable = (text) => {
     const lines = text.trim().split('\n');
     if (lines.length < 2) return '<p>No data</p>';
 
     const headers = lines[0].split('\t');
+    const visibleIndices = headers.map((h, i) => i).filter(i => !hiddenColumns.has(headers[i]));
     const rows = lines.slice(1).reverse();
 
     let html = '<table class="server-metrics-table"><thead><tr>';
-    headers.forEach(h => { html += `<th>${labelMap[h] || h}</th>`; });
+    visibleIndices.forEach(i => { html += `<th>${labelMap[headers[i]] || headers[i]}</th>`; });
     html += '</tr></thead><tbody>';
     rows.forEach(line => {
       const cols = line.split('\t');
       html += '<tr>';
-      cols.forEach((col, i) => {
-        let val = col;
+      visibleIndices.forEach(i => {
+        let val = cols[i];
         if (headers[i] === 'timestamp') {
-          val = col.replace(/T/, ' ').replace(/\+.*/, '');
+          val = cols[i].replace(/T/, ' ').replace(/\+.*/, '');
         } else if (headers[i].match(/mem_|swap_/)) {
-          val = `${col} MB`;
-        } else if (headers[i].match(/disk_(used|avail)/)) {
-          val = `${col} GB`;
-        } else if (headers[i] === 'disk_use_pct') {
-          val = `${col}%`;
+          val = `${cols[i]} MB`;
         }
         html += `<td>${val}</td>`;
       });


### PR DESCRIPTION
Default to 1-hour aggregated averages instead of 5-minute intervals
for better readability. Raw 5-minute data still available via ?raw=1.
Hide disk usage columns from dashboard as they rarely change.

https://claude.ai/code/session_015TvF2aJ5NjbyqVpBn68Tpr